### PR TITLE
fix: bump consultations to 0.1.2 and fix entry path

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-@coongro:registry=http://localhost:4873/
+@coongro:registry=https://registry.coongro.com/

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -1,8 +1,8 @@
 {
   "id": "consultations",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "apiVersion": "2.0",
-  "entry": "./dist/entry.js",
+  "entry": "dist/entry.js",
   "assets": {
     "styles": [
       "./dist/assets/tailwind.css"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coongro/consultations",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "type": "module",
   "description": "Bloque de historia clinica: consultas veterinarias, diagnosticos y tratamientos",
   "main": "dist/index.js",
@@ -24,7 +24,6 @@
   "scripts": {
     "build": "npm run build:css && tsc",
     "build:css": "tailwindcss -c tailwind.config.cjs -i ./src/styles/tailwind.css -o ./dist/assets/tailwind.css --minify",
-
     "dev": "npm run build:css && tsc --watch",
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
@@ -39,7 +38,7 @@
     "prepublishOnly": "npm run quality && npm run build"
   },
   "publishConfig": {
-    "registry": "http://localhost:4873/"
+    "registry": "https://registry.coongro.com/"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -49,7 +48,7 @@
     "@coongro/products": ">=0.1.0"
   },
   "peerDependencies": {
-    "@coongro/plugin-sdk": ">=0.1.0"
+    "@coongro/plugin-sdk": ">=0.13.0"
   },
   "devDependencies": {
     "@coongro/plugin-sdk": "workspace:*",


### PR DESCRIPTION
Closes #255

## Changes
- Bump version from 0.1.0 to 0.1.2
- Fix `entry` path in manifest: `./dist/entry.js` → `dist/entry.js`
- Update `publishConfig.registry` to production (`registry.coongro.com`)
- Fix `.npmrc` registry to production
- Update `peerDependencies` minimum to `>=0.13.0`

## Testing
- Install `@coongro/consultations` in a tenant
- Verify auto-seed of veterinary service categories runs on first activation
- Confirm `@coongro/products` cross-plugin import resolves correctly in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.1.2.
  * Updated npm registry configuration for package distribution.
  * Updated peer dependency compatibility requirement for @coongro/plugin-sdk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->