### PR TITLE
refactor: add reusable CreateConsultationButton component

### DIFF
--- a/src/components/CreateConsultationButton.tsx
+++ b/src/components/CreateConsultationButton.tsx
@@ -1,0 +1,129 @@
+/**
+ * Botón para crear consulta. Abre un FormDialog con PetPicker + ConsultationForm.
+ *
+ * Modos de uso:
+ *   - Sin petId: muestra PetPicker para seleccionar mascota, luego ConsultationForm
+ *   - Con petId: abre ConsultationForm directamente
+ *   - Modo controlado (open + onOpenChange): no renderiza el botón, el caller controla la apertura
+ */
+import { PetPicker } from '@coongro/patients';
+import type { Pet } from '@coongro/patients';
+import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
+import type { CreateConsultationButtonProps } from '../types/components.js';
+import type { Consultation } from '../types/consultation.js';
+
+import { ConsultationForm } from './ConsultationForm.js';
+
+const React = getHostReact();
+const UI = getHostUI();
+const { useState, useCallback } = React;
+
+export function CreateConsultationButton(props: CreateConsultationButtonProps) {
+  const {
+    petId: petIdProp,
+    label = 'Nueva consulta',
+    onSuccess,
+    onCancel,
+    variant = 'primary',
+    open: openProp,
+    onOpenChange,
+  } = props;
+
+  const isControlled = openProp !== undefined;
+  const [openState, setOpenState] = useState(false);
+  const open = isControlled ? openProp : openState;
+
+  const [selectedPetId, setSelectedPetId] = useState<string | undefined>(petIdProp);
+
+  const setOpen = useCallback(
+    (val: boolean) => {
+      if (!isControlled) setOpenState(val);
+      onOpenChange?.(val);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const handleOpen = useCallback(() => {
+    setSelectedPetId(petIdProp);
+    setOpen(true);
+  }, [petIdProp, setOpen]);
+
+  const handleClose = useCallback(() => {
+    setSelectedPetId(petIdProp);
+    setOpen(false);
+    onCancel?.();
+  }, [petIdProp, setOpen, onCancel]);
+
+  const handleSuccess = useCallback(
+    (c: Consultation) => {
+      setSelectedPetId(petIdProp);
+      setOpen(false);
+      onSuccess?.(c);
+    },
+    [petIdProp, setOpen, onSuccess]
+  );
+
+  return React.createElement(
+    React.Fragment,
+    null,
+
+    // Botón (solo en modo no controlado)
+    !isControlled &&
+      React.createElement(
+        UI.Button,
+        {
+          type: 'button',
+          variant: variant === 'primary' ? 'brand' : 'outline',
+          onClick: handleOpen,
+          className: 'gap-2',
+        },
+        React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 20 }),
+        label
+      ),
+
+    // Modal
+    React.createElement(
+      UI.FormDialog,
+      {
+        open,
+        onOpenChange: (val: boolean) => {
+          if (!val) handleClose();
+        },
+        title: label,
+        size: 'lg',
+      },
+      petIdProp
+        ? // Con petId: formulario directo
+          React.createElement(ConsultationForm, {
+            petId: petIdProp,
+            onSuccess: handleSuccess,
+            onCancel: handleClose,
+          })
+        : // Sin petId: PetPicker primero, luego formulario
+          React.createElement(
+            'div',
+            { className: 'flex flex-col gap-4' },
+            React.createElement(
+              'div',
+              { className: 'flex flex-col gap-1' },
+              React.createElement(UI.Label, null, 'Paciente *'),
+              React.createElement(PetPicker, {
+                value: selectedPetId,
+                onChange: (pet: Pet | null) => setSelectedPetId(pet?.id),
+                placeholder: 'Seleccionar mascota...',
+              })
+            ),
+            selectedPetId
+              ? React.createElement(ConsultationForm, {
+                  petId: selectedPetId,
+                  onSuccess: handleSuccess,
+                  onCancel: handleClose,
+                })
+              : React.createElement(UI.EmptyState, {
+                  title: 'Seleccioná un paciente para continuar',
+                })
+          )
+    )
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
 
 // Componentes
 export { ConsultationCard } from './components/ConsultationCard.js';
+export { CreateConsultationButton } from './components/CreateConsultationButton.js';
 export { ConsultationTimeline } from './components/ConsultationTimeline.js';
 export { ConsultationDetail } from './components/ConsultationDetail.js';
 export { ConsultationForm } from './components/ConsultationForm.js';
@@ -39,6 +40,7 @@ export type {
   ConsultationDetailProps,
   MedicationListProps,
   MedicationFormListProps,
+  CreateConsultationButtonProps,
 } from './types/components.js';
 
 // Utils

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -81,6 +81,22 @@ export interface ConsultationDetailProps {
 }
 
 // ---------------------------------------------------------------------------
+// CreateConsultationButton
+// ---------------------------------------------------------------------------
+
+export interface CreateConsultationButtonProps {
+  /** ID del paciente. Si se omite, muestra PetPicker para seleccionarlo. */
+  petId?: string;
+  label?: string;
+  onSuccess?: (consultation: Consultation) => void;
+  onCancel?: () => void;
+  variant?: 'primary' | 'outline';
+  /** Modo controlado: si se provee, no renderiza el botón y el caller maneja la apertura */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+// ---------------------------------------------------------------------------
 // MedicationList
 // ---------------------------------------------------------------------------
 

--- a/src/views/consultations-list/index.tsx
+++ b/src/views/consultations-list/index.tsx
@@ -1,11 +1,9 @@
 /**
  * Vista principal: historial de consultas con stats, filtros inline y tabla.
  */
-import { PetPicker } from '@coongro/patients';
-import type { Pet } from '@coongro/patients';
 import { getHostReact, getHostUI, usePlugin, actions } from '@coongro/plugin-sdk';
 
-import { ConsultationForm } from '../../components/ConsultationForm.js';
+import { CreateConsultationButton } from '../../components/CreateConsultationButton.js';
 import { ConsultationStats } from '../../components/ConsultationStats.js';
 import { useConsultations } from '../../hooks/useConsultations.js';
 import { useConsultationsSettings } from '../../hooks/useConsultationsSettings.js';
@@ -55,8 +53,6 @@ export function ConsultationsListView() {
   const { settings: consultSettings } = useConsultationsSettings();
 
   const [localSearch, setLocalSearch] = useState('');
-  const [showCreateModal, setShowCreateModal] = useState(false);
-  const [selectedPetId, setSelectedPetId] = useState<string | undefined>(undefined);
   const [sortKey, setSortKey] = useState<string>('date');
   const [sortDir, setSortDir] = useState<SortDirection>('desc');
 
@@ -132,24 +128,12 @@ export function ConsultationsListView() {
     [views]
   );
 
-  const handleCreate = useCallback(() => {
-    setSelectedPetId(undefined);
-    setShowCreateModal(true);
-  }, []);
-
   const handleCreateSuccess = useCallback(
     (c: Consultation) => {
-      setShowCreateModal(false);
-      setSelectedPetId(undefined);
       views.open('consultations.detail.open', { consultationId: c.id });
     },
     [views]
   );
-
-  const handleCreateCancel = useCallback(() => {
-    setShowCreateModal(false);
-    setSelectedPetId(undefined);
-  }, []);
 
   const handleSearchChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -360,12 +344,9 @@ export function ConsultationsListView() {
             'Historial de consultas veterinarias'
           )
         ),
-        React.createElement(
-          UI.Button,
-          { onClick: handleCreate },
-          React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 16 }),
-          'Nueva Consulta'
-        )
+        React.createElement(CreateConsultationButton, {
+          onSuccess: handleCreateSuccess,
+        })
       ),
 
       // ── Stats ──
@@ -575,47 +556,6 @@ export function ConsultationsListView() {
             )
         )
       )
-    ),
-
-    // ── Modal nueva consulta ──
-    showCreateModal &&
-      React.createElement(
-        UI.FormDialog,
-        {
-          open: showCreateModal,
-          onOpenChange: (open: boolean) => {
-            if (!open) handleCreateCancel();
-          },
-          title: 'Nueva consulta',
-          size: 'lg',
-        },
-        React.createElement(
-          'div',
-          { className: 'flex flex-col gap-4' },
-
-          // Selector de mascota
-          React.createElement(
-            'div',
-            { className: 'flex flex-col gap-1' },
-            React.createElement(UI.Label, null, 'Paciente *'),
-            React.createElement(PetPicker, {
-              value: selectedPetId,
-              onChange: (pet: Pet | null) => setSelectedPetId(pet?.id),
-              placeholder: 'Seleccionar mascota...',
-            })
-          ),
-
-          // Formulario de consulta (solo si hay mascota seleccionada)
-          selectedPetId
-            ? React.createElement(ConsultationForm, {
-                petId: selectedPetId,
-                onSuccess: handleCreateSuccess,
-                onCancel: handleCreateCancel,
-              })
-            : React.createElement(UI.EmptyState, {
-                title: 'Seleccioná un paciente para continuar',
-              })
-        )
-      )
+    )
   );
 }

--- a/src/views/detail-override/index.tsx
+++ b/src/views/detail-override/index.tsx
@@ -6,7 +6,7 @@ import { PetDetail, PetForm } from '@coongro/patients';
 import type { Pet } from '@coongro/patients';
 import { getHostReact, getHostUI, usePlugin } from '@coongro/plugin-sdk';
 
-import { ConsultationForm } from '../../components/ConsultationForm.js';
+import { CreateConsultationButton } from '../../components/CreateConsultationButton.js';
 import { ConsultationTimeline } from '../../components/ConsultationTimeline.js';
 import type { Consultation } from '../../types/consultation.js';
 
@@ -36,13 +36,8 @@ export function DetailOverrideView(props: { petId?: string }) {
     toast.success('Paciente actualizado', 'Los datos se guardaron correctamente');
   }, [toast]);
 
-  const handleNewConsultation = useCallback(() => {
-    setShowConsultationModal(true);
-  }, []);
-
   const handleConsultationSuccess = useCallback(
     (c: Consultation) => {
-      setShowConsultationModal(false);
       setRefreshKey((k: number) => k + 1);
       views.open('consultations.detail.open', { consultationId: c.id });
     },
@@ -89,7 +84,7 @@ export function DetailOverrideView(props: { petId?: string }) {
   const extraActions = [
     {
       label: 'Nueva Consulta',
-      onClick: handleNewConsultation,
+      onClick: () => setShowConsultationModal(true),
     },
   ];
 
@@ -128,21 +123,11 @@ export function DetailOverrideView(props: { petId?: string }) {
         }),
       ),
 
-    // Modal de nueva consulta
-    showConsultationModal &&
-      React.createElement(
-        UI.FormDialog,
-        {
-          open: showConsultationModal,
-          onOpenChange: (open: boolean) => { if (!open) setShowConsultationModal(false); },
-          title: 'Nueva consulta',
-          size: 'lg',
-        },
-        React.createElement(ConsultationForm, {
-          petId,
-          onSuccess: handleConsultationSuccess,
-          onCancel: () => setShowConsultationModal(false),
-        }),
-      ),
+    React.createElement(CreateConsultationButton, {
+      petId,
+      open: showConsultationModal,
+      onOpenChange: setShowConsultationModal,
+      onSuccess: handleConsultationSuccess,
+    }),
   );
 }


### PR DESCRIPTION
Closes #2

## Changes
- Add `CreateConsultationButton` component (analogous to `CreatePetButton` from `@coongro/patients`)
- Uncontrolled mode: renders button + FormDialog internally
- Controlled mode: `open`/`onOpenChange` props, caller manages button placement (used in `detail-override` via `extraActions`)
- With `petId`: opens `ConsultationForm` directly; without `petId`: shows `PetPicker` → `ConsultationForm`
- Refactor `consultations-list` to remove ~45 lines of inline FormDialog logic
- Refactor `detail-override` to use controlled `CreateConsultationButton`
- Export `CreateConsultationButton` and `CreateConsultationButtonProps` from package index

## Testing
- [ ] "Nueva consulta" en consultations-list abre dialog con PetPicker
- [ ] Seleccionar mascota muestra ConsultationForm
- [ ] Guardar consulta navega al detalle
- [ ] "Nueva consulta" en detalle de mascota abre dialog directo (sin PetPicker)
- [ ] Build pasa sin errores: `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new consultation creation button component with support for pre-selected patients and flexible configuration options.

* **Improvements**
  * Refactored consultation creation workflows in multiple views to use a dedicated, reusable button component.
  * Simplified the patient selection and consultation creation process for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->