### PR TITLE
fix: normalize layout tokens and redesign services/list views

### DIFF
--- a/.changeset/normalize-layout-tokens.md
+++ b/.changeset/normalize-layout-tokens.md
@@ -1,0 +1,12 @@
+---
+"@coongro/consultations": minor
+---
+
+Normalize layout tokens and redesign services/list views
+
+- Extract shared price/category utilities and reusable PriceInput/ServiceFormDialog components
+- Lift data fetching to parent views for better component reusability
+- Redesign consultations list with consolidated columns, PageHeader, and improved empty states
+- Redesign services view with server-side category filtering and pagination
+- Add onViewAll prop to ConsultationTimeline for navigation
+- New public exports: PriceInput, ServiceFormDialog, formatCurrency, formatPrice, sanitizePrice, isValidPrice, createCategoryMap

--- a/package-lock.json
+++ b/package-lock.json
@@ -335,7 +335,7 @@
     "node_modules/@coongro/contacts": {
       "version": "1.0.5",
       "resolved": "https://coongro-staging.up.railway.app/@coongro/contacts/-/contacts-1.0.5.tgz",
-      "integrity": "sha512-nijW8+8rxD9tSCbiECi/Por9aU5pGJ18u21kQsDDI756/Ro8Z32lUNXSCUODAEiPQ8rlIANrh/9ynQplSBsCMg==",
+      "integrity": "sha512-9kaj0YlJBYEir6n/AIL08Ksm78UQOnQxPhRWaRSOrml5aN30+FR+wjwJCHcBDXcoO92Aw1nEqCt7pboJJ3mHAw==",
       "engines": {
         "node": ">=18.0.0"
       },
@@ -407,7 +407,7 @@
     "node_modules/@coongro/patients": {
       "version": "1.0.3",
       "resolved": "https://coongro-staging.up.railway.app/@coongro/patients/-/patients-1.0.3.tgz",
-      "integrity": "sha512-KtI/ywneO+C4GyhqTvG4gezRxmgzxGQbqop+DD+zgXtax1tWOSuYB/iaFJJrXB2cBLW8vVKu28Sqd3rQLNhY/A==",
+      "integrity": "sha512-Ju1p7l5peNgw4I+f3IHQ/KWZBxm/zuuelRbQCwhcIcjA7sVKXEg9pgvsvxvJafDOFvJWR+PLotJu/01M0PE7OQ==",
       "dependencies": {
         "@coongro/contacts": ">=1.0.0"
       },
@@ -436,7 +436,7 @@
     "node_modules/@coongro/products": {
       "version": "1.0.3",
       "resolved": "https://coongro-staging.up.railway.app/@coongro/products/-/products-1.0.3.tgz",
-      "integrity": "sha512-MQ5V6uTB//c7YXpvmEXiLv/O3/rRH8XNPZjL+w+QM2R1yHQrPW4DhVPFFewFBdv8qDZtAkB7pZPVsqjlJPD0Yw==",
+      "integrity": "sha512-GL6zF1CCmmcTYYp8x0aX/NDLn3SEkmITviuF44bOMneft2aXB9TGrlw4cFLIhg7aKldgtfwrGJ5gmMx8fLVyGQ==",
       "engines": {
         "node": ">=18.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -373,9 +373,9 @@
       }
     },
     "node_modules/@coongro/design-tokens": {
-      "version": "0.15.1",
-      "resolved": "https://coongro-staging.up.railway.app/@coongro/design-tokens/-/686a658053a0ea4c0c38bd5a83a4fd89ca2cebc2",
-      "integrity": "sha512-Pqg2L2ddBuFk2dIQ3XPeBrrk5Xk/7YvxbK22w/ZVIwGrB6jmf1Ddv5IkcJt3OL+Y3z865yiRWvBgRWkW8Xsz2w==",
+      "version": "0.16.0",
+      "resolved": "https://coongro-staging.up.railway.app/@coongro/design-tokens/-/9f10bbecea75cca5f91189c6865a20de54a119d5",
+      "integrity": "sha512-L6wSsDxqP1ob1t44/3Vqy/HVuH4ZkdjaILV8IbE7IXVPVs+4UCMujkQsJkzVlkk7myJ956eMlmIAhcdIdI+VBQ==",
       "peer": true,
       "engines": {
         "node": ">=18.0.0"
@@ -446,12 +446,12 @@
       }
     },
     "node_modules/@coongro/ui-components": {
-      "version": "0.15.1",
-      "resolved": "https://coongro-staging.up.railway.app/@coongro/ui-components/-/13959f11b2ed38b8e121d6436645ebdaa8c80744",
-      "integrity": "sha512-n0/BauishvckmPvLssBksbpOJuntli6dPFYrmo9sTyUfrW0N9Oruqyw3+tN6SaVjG/GI2bvHjEsSK8msR5mNYQ==",
+      "version": "0.16.0",
+      "resolved": "https://coongro-staging.up.railway.app/@coongro/ui-components/-/c8c9db7b651d861fef6f3b5ca44a7e4300f03fdb",
+      "integrity": "sha512-bMrNU9PFg/oIT0vN8YH9OdLMpwGddy0057bIuMg9n3Vd1kh5b4LQd7Q6uI2GZiqj7WteUsU1zi/v7QWA1WALzg==",
       "peer": true,
       "dependencies": {
-        "@coongro/design-tokens": "0.15.1",
+        "@coongro/design-tokens": "0.16.0",
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-checkbox": "^1.1.3",
         "@radix-ui/react-context-menu": "^2.2.5",

--- a/src/components/ConsultationCard.tsx
+++ b/src/components/ConsultationCard.tsx
@@ -16,14 +16,7 @@ const React = getHostReact();
 const UI = getHostUI();
 
 export function ConsultationCard(props: ConsultationCardProps) {
-  const {
-    consultation: c,
-    showPetName: _showPetName,
-    amount,
-    onClick,
-    actions: cardActions,
-    className = '',
-  } = props;
+  const { consultation: c, amount, onClick, actions: cardActions, className = '' } = props;
 
   const emoji = getReasonCategoryEmoji(c.reason_category);
   const badgeVariant = getReasonCategoryBadgeVariant(c.reason_category);
@@ -33,7 +26,7 @@ export function ConsultationCard(props: ConsultationCardProps) {
   return React.createElement(
     UI.Card,
     {
-      className: `p-3 ${onClick ? 'cursor-pointer hover:bg-[var(--cg-bg-hover)]' : ''} transition-colors ${className}`,
+      className: `p-3 ${onClick ? 'cursor-pointer hover:bg-cg-bg-hover' : ''} transition-colors ${className}`,
       onClick: onClick ? () => onClick(c) : undefined,
     },
     React.createElement(
@@ -52,14 +45,10 @@ export function ConsultationCard(props: ConsultationCardProps) {
         React.createElement(
           'div',
           { className: 'flex items-center gap-2 flex-wrap' },
+          React.createElement('span', { className: 'text-sm font-medium text-cg-text' }, dateStr),
           React.createElement(
             'span',
-            { className: 'text-sm font-medium text-[var(--cg-text)]' },
-            dateStr
-          ),
-          React.createElement(
-            'span',
-            { className: 'text-xs text-[var(--cg-text-muted)]' },
+            { className: 'text-xs text-cg-text-muted' },
             `— ${c.vet_name}`
           ),
           categoryLabel &&
@@ -71,17 +60,13 @@ export function ConsultationCard(props: ConsultationCardProps) {
         ),
 
         // Motivo
-        React.createElement(
-          'p',
-          { className: 'text-sm text-[var(--cg-text)] mt-1 line-clamp-1' },
-          c.reason
-        ),
+        React.createElement('p', { className: 'text-sm text-cg-text mt-1 line-clamp-1' }, c.reason),
 
         // Diagnostico (si hay)
         c.diagnosis &&
           React.createElement(
             'p',
-            { className: 'text-xs text-[var(--cg-text-muted)] mt-0.5 line-clamp-1' },
+            { className: 'text-xs text-cg-text-muted mt-0.5 line-clamp-1' },
             `Dx: ${c.diagnosis}`
           ),
 
@@ -92,19 +77,19 @@ export function ConsultationCard(props: ConsultationCardProps) {
           c.weight_kg &&
             React.createElement(
               'span',
-              { className: 'text-xs text-[var(--cg-text-muted)]' },
+              { className: 'text-xs text-cg-text-muted' },
               `⚖️ ${c.weight_kg} kg`
             ),
           c.temperature &&
             React.createElement(
               'span',
-              { className: 'text-xs text-[var(--cg-text-muted)]' },
+              { className: 'text-xs text-cg-text-muted' },
               `🌡️ ${c.temperature}°C`
             ),
           c.follow_up_date &&
             React.createElement(
               'span',
-              { className: 'text-xs text-[var(--cg-text-muted)]' },
+              { className: 'text-xs text-cg-text-muted' },
               `📅 Control: ${formatConsultationDate(c.follow_up_date)}`
             ),
           amount !== null &&
@@ -112,7 +97,7 @@ export function ConsultationCard(props: ConsultationCardProps) {
             amount > 0 &&
             React.createElement(
               'span',
-              { className: 'text-xs font-medium text-[var(--cg-accent)]' },
+              { className: 'text-xs font-medium text-cg-accent' },
               formatCurrency(amount)
             )
         )

--- a/src/components/ConsultationCard.tsx
+++ b/src/components/ConsultationCard.tsx
@@ -10,6 +10,7 @@ import {
   getReasonCategoryBadgeVariant,
   getReasonCategoryEmoji,
 } from '../utils/labels.js';
+import { formatCurrency } from '../utils/price.js';
 
 const React = getHostReact();
 const UI = getHostUI();
@@ -112,7 +113,7 @@ export function ConsultationCard(props: ConsultationCardProps) {
             React.createElement(
               'span',
               { className: 'text-xs font-medium text-[var(--cg-accent)]' },
-              `$${amount.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`
+              formatCurrency(amount)
             )
         )
       ),

--- a/src/components/ConsultationDetail.tsx
+++ b/src/components/ConsultationDetail.tsx
@@ -1,6 +1,6 @@
 /**
  * Vista detallada de una consulta con layout de dos columnas.
- * Header con info de mascota, sidebar sticky (vet, vitales, seguimiento),
+ * Encabezado con info de mascota, panel lateral sticky (vet, vitales, seguimiento),
  * y contenido clínico principal.
  */
 import { getHostReact, getHostUI, useViewContributions } from '@coongro/plugin-sdk';
@@ -63,7 +63,6 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
     onEdit,
     onDelete,
     onBack,
-    onNavigate: _onNavigate,
     className = '',
   } = props;
 
@@ -77,7 +76,7 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
     medications,
   });
 
-  // --- Loading ---
+  // --- Cargando ---
   if (loading) {
     return React.createElement(
       'div',
@@ -140,6 +139,10 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
   ].filter((s) => s.value);
 
   const hasVitals = c.weight_kg || c.temperature;
+  const servicesTotal = services.reduce(
+    (acc: number, s: ConsultationService) => acc + (parseFloat(s.subtotal) || 0),
+    0
+  );
 
   // Info de mascota para el header
   const petEmoji = pet ? (SPECIES_EMOJI[pet.species] ?? '🐾') : '🐾';
@@ -251,12 +254,12 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
       )
     ),
 
-    // ── Two-column body ──
+    // ── Cuerpo en dos columnas ──
     React.createElement(
       'div',
       { className: 'flex flex-col lg:flex-row gap-6' },
 
-      // ── SIDEBAR ──
+      // ── PANEL LATERAL ──
       React.createElement(
         'div',
         {
@@ -407,7 +410,7 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
         )
       ),
 
-      // ── MAIN CONTENT ──
+      // ── CONTENIDO PRINCIPAL ──
       React.createElement(
         'div',
         {
@@ -499,142 +502,131 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
         // Servicios prestados
         consultSettings.showPrices &&
           services.length > 0 &&
-          (() => {
-            const servicesTotal = services.reduce(
-              (acc: number, s: ConsultationService) => acc + parseFloat(s.subtotal),
-              0
-            );
-            return React.createElement(
-              UI.Card,
-              { className: 'overflow-hidden' },
-              // Header
+          React.createElement(
+            UI.Card,
+            { className: 'overflow-hidden' },
+            React.createElement(
+              'div',
+              {
+                className:
+                  'px-5 py-3 border-b border-cg-border bg-cg-bg-secondary flex items-center gap-2',
+              },
+              React.createElement(UI.DynamicIcon, {
+                icon: 'ClipboardList',
+                size: 15,
+                className: 'text-cg-text-muted',
+              }),
+              React.createElement(
+                'h2',
+                { className: 'text-sm font-semibold text-cg-text' },
+                'Servicios prestados'
+              )
+            ),
+            // Resumen: cantidad + total
+            React.createElement(
+              'div',
+              { className: 'px-5 py-4 flex items-center gap-4' },
               React.createElement(
                 'div',
-                {
-                  className:
-                    'px-5 py-3 border-b border-cg-border bg-cg-bg-secondary flex items-center gap-2',
-                },
+                { className: 'flex items-center gap-2 px-3 py-2 rounded-lg bg-cg-bg-secondary' },
                 React.createElement(UI.DynamicIcon, {
-                  icon: 'ClipboardList',
-                  size: 15,
+                  icon: 'Package',
+                  size: 16,
                   className: 'text-cg-text-muted',
                 }),
                 React.createElement(
-                  'h2',
-                  { className: 'text-sm font-semibold text-cg-text' },
-                  'Servicios prestados'
+                  'div',
+                  null,
+                  React.createElement(
+                    'span',
+                    { className: 'text-xs text-cg-text-muted block' },
+                    'Servicios'
+                  ),
+                  React.createElement(
+                    'span',
+                    { className: 'text-sm font-semibold text-cg-text' },
+                    String(services.length)
+                  )
                 )
               ),
-              // Resumen: cantidad + total
               React.createElement(
                 'div',
-                { className: 'px-5 py-4 flex items-center gap-4' },
+                { className: 'flex items-center gap-2 px-4 py-2 rounded-lg bg-cg-success-bg' },
+                React.createElement(UI.DynamicIcon, {
+                  icon: 'DollarSign',
+                  size: 16,
+                  className: 'text-cg-success-text',
+                }),
                 React.createElement(
                   'div',
-                  { className: 'flex items-center gap-2 px-3 py-2 rounded-lg bg-cg-bg-secondary' },
-                  React.createElement(UI.DynamicIcon, {
-                    icon: 'Package',
-                    size: 16,
-                    className: 'text-cg-text-muted',
-                  }),
+                  null,
                   React.createElement(
-                    'div',
+                    'span',
+                    { className: 'text-xs text-cg-text-muted block' },
+                    'Total'
+                  ),
+                  React.createElement(
+                    'span',
+                    { className: 'text-lg font-bold text-cg-success-text' },
+                    formatCurrency(servicesTotal)
+                  )
+                )
+              )
+            ),
+            // Tabla de detalle
+            React.createElement(
+              'div',
+              { className: 'overflow-x-auto' },
+              React.createElement(
+                UI.Table,
+                null,
+                React.createElement(
+                  UI.TableHeader,
+                  null,
+                  React.createElement(
+                    UI.TableRow,
                     null,
-                    React.createElement(
-                      'span',
-                      { className: 'text-xs text-cg-text-muted block' },
-                      'Servicios'
-                    ),
-                    React.createElement(
-                      'span',
-                      { className: 'text-sm font-semibold text-cg-text' },
-                      String(services.length)
-                    )
+                    React.createElement(UI.TableHead, null, 'Servicio'),
+                    React.createElement(UI.TableHead, { className: 'text-center' }, 'Cant.'),
+                    React.createElement(UI.TableHead, { className: 'text-right' }, 'Precio'),
+                    React.createElement(UI.TableHead, { className: 'text-right' }, 'Subtotal')
                   )
                 ),
                 React.createElement(
-                  'div',
-                  { className: 'flex items-center gap-2 px-4 py-2 rounded-lg bg-cg-success-bg' },
-                  React.createElement(UI.DynamicIcon, {
-                    icon: 'DollarSign',
-                    size: 16,
-                    className: 'text-cg-success-text',
-                  }),
-                  React.createElement(
-                    'div',
-                    null,
-                    React.createElement(
-                      'span',
-                      { className: 'text-xs text-cg-text-muted block' },
-                      'Total'
-                    ),
-                    React.createElement(
-                      'span',
-                      { className: 'text-lg font-bold text-cg-success-text' },
-                      formatCurrency(servicesTotal)
-                    )
-                  )
-                )
-              ),
-              // Tabla de detalle
-              React.createElement(
-                'div',
-                { className: 'overflow-x-auto' },
-                React.createElement(
-                  UI.Table,
+                  UI.TableBody,
                   null,
-                  React.createElement(
-                    UI.TableHeader,
-                    null,
+                  services.map((svc: ConsultationService) =>
                     React.createElement(
                       UI.TableRow,
-                      null,
-                      React.createElement(UI.TableHead, null, 'Servicio'),
-                      React.createElement(UI.TableHead, { className: 'text-center' }, 'Cant.'),
-                      React.createElement(UI.TableHead, { className: 'text-right' }, 'Precio'),
-                      React.createElement(UI.TableHead, { className: 'text-right' }, 'Subtotal')
-                    )
-                  ),
-                  React.createElement(
-                    UI.TableBody,
-                    null,
-                    services.map((svc: ConsultationService) =>
+                      { key: svc.id },
                       React.createElement(
-                        UI.TableRow,
-                        { key: svc.id },
-                        React.createElement(
-                          UI.TableCell,
-                          { className: 'font-medium' },
-                          svc.product_name,
-                          svc.notes &&
-                            React.createElement(
-                              'span',
-                              { className: 'text-xs text-cg-text-muted ml-2 font-normal' },
-                              `(${svc.notes})`
-                            )
-                        ),
-                        React.createElement(
-                          UI.TableCell,
-                          { className: 'text-center' },
-                          svc.quantity
-                        ),
-                        React.createElement(
-                          UI.TableCell,
-                          { className: 'text-right' },
-                          formatCurrency(parseFloat(svc.unit_price))
-                        ),
-                        React.createElement(
-                          UI.TableCell,
-                          { className: 'text-right font-medium' },
-                          formatCurrency(parseFloat(svc.subtotal))
-                        )
+                        UI.TableCell,
+                        { className: 'font-medium' },
+                        svc.product_name,
+                        svc.notes &&
+                          React.createElement(
+                            'span',
+                            { className: 'text-xs text-cg-text-muted ml-2 font-normal' },
+                            `(${svc.notes})`
+                          )
+                      ),
+                      React.createElement(UI.TableCell, { className: 'text-center' }, svc.quantity),
+                      React.createElement(
+                        UI.TableCell,
+                        { className: 'text-right' },
+                        formatCurrency(parseFloat(svc.unit_price))
+                      ),
+                      React.createElement(
+                        UI.TableCell,
+                        { className: 'text-right font-medium' },
+                        formatCurrency(parseFloat(svc.subtotal))
                       )
                     )
                   )
                 )
               )
-            );
-          })(),
+            )
+          ),
 
         // Secciones extra (plugins)
         ...sortedSections.map((section, i) =>

--- a/src/components/ConsultationDetail.tsx
+++ b/src/components/ConsultationDetail.tsx
@@ -3,7 +3,7 @@
  * Header con info de mascota, sidebar sticky (vet, vitales, seguimiento),
  * y contenido clínico principal.
  */
-import { getHostReact, getHostUI, useViewContributions, actions } from '@coongro/plugin-sdk';
+import { getHostReact, getHostUI, useViewContributions } from '@coongro/plugin-sdk';
 
 import { useConsultation } from '../hooks/useConsultation.js';
 import { useConsultationsSettings } from '../hooks/useConsultationsSettings.js';
@@ -14,13 +14,12 @@ import {
   formatReasonCategory,
   getReasonCategoryBadgeVariant,
 } from '../utils/labels.js';
+import { formatCurrency } from '../utils/price.js';
 
 import { MedicationList } from './MedicationList.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useState, useEffect, useRef } = React;
-
 // Mapa de secciones clínicas -> iconos lucide
 const SECTION_ICONS: Record<string, string> = {
   'Motivo de consulta': 'ClipboardList',
@@ -44,14 +43,6 @@ const SEX_LABELS: Record<string, string> = {
   unknown: 'Desconocido',
 };
 
-interface PetInfo {
-  name: string;
-  species: string;
-  breed: string | null;
-  birth_date: string | null;
-  sex: string | null;
-}
-
 function calculateAge(birthDate: string | null): string {
   if (!birthDate) return '';
   const birth = new Date(birthDate);
@@ -66,6 +57,7 @@ function calculateAge(birthDate: string | null): string {
 export function ConsultationDetail(props: ConsultationDetailProps) {
   const {
     consultationId,
+    pet = null,
     extraSections = [],
     extraActions = [],
     onEdit,
@@ -84,29 +76,6 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
     consultationId,
     medications,
   });
-
-  // Fetch de datos de la mascota
-  const [pet, setPet] = useState<PetInfo | null>(null);
-  const petFetchedRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    if (!consultation?.pet_id || petFetchedRef.current === consultation.pet_id) return;
-    petFetchedRef.current = consultation.pet_id;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const result = await actions.execute<PetInfo>('patients.pets.getById', {
-          id: consultation.pet_id,
-        });
-        if (!cancelled && result) setPet(result);
-      } catch {
-        // Silencioso — el header muestra fallback sin datos de mascota
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [consultation?.pet_id]);
 
   // --- Loading ---
   if (loading) {
@@ -602,7 +571,7 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
                     React.createElement(
                       'span',
                       { className: 'text-lg font-bold text-cg-success-text' },
-                      `$${servicesTotal.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`
+                      formatCurrency(servicesTotal)
                     )
                   )
                 )
@@ -652,12 +621,12 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
                         React.createElement(
                           UI.TableCell,
                           { className: 'text-right' },
-                          `$${parseFloat(svc.unit_price).toLocaleString('es-AR', { minimumFractionDigits: 2 })}`
+                          formatCurrency(parseFloat(svc.unit_price))
                         ),
                         React.createElement(
                           UI.TableCell,
                           { className: 'text-right font-medium' },
-                          `$${parseFloat(svc.subtotal).toLocaleString('es-AR', { minimumFractionDigits: 2 })}`
+                          formatCurrency(parseFloat(svc.subtotal))
                         )
                       )
                     )

--- a/src/components/ConsultationDetail.tsx
+++ b/src/components/ConsultationDetail.tsx
@@ -3,11 +3,11 @@
  * Encabezado con info de mascota, panel lateral sticky (vet, vitales, seguimiento),
  * y contenido clínico principal.
  */
-import { getHostReact, getHostUI, useViewContributions } from '@coongro/plugin-sdk';
+import { getHostReact, getHostUI, useViewContributions, actions } from '@coongro/plugin-sdk';
 
 import { useConsultation } from '../hooks/useConsultation.js';
 import { useConsultationsSettings } from '../hooks/useConsultationsSettings.js';
-import type { ConsultationDetailProps } from '../types/components.js';
+import type { ConsultationDetailProps, PetInfo } from '../types/components.js';
 import type { ConsultationService } from '../types/consultation.js';
 import {
   formatConsultationDateTime,
@@ -20,7 +20,8 @@ import { MedicationList } from './MedicationList.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-// Mapa de secciones clínicas -> iconos lucide
+const { useState, useEffect, useRef } = React;
+// Mapa de secciones clínicas a nombres de iconos Lucide
 const SECTION_ICONS: Record<string, string> = {
   'Motivo de consulta': 'ClipboardList',
   Anamnesis: 'MessageSquare',
@@ -57,7 +58,7 @@ function calculateAge(birthDate: string | null): string {
 export function ConsultationDetail(props: ConsultationDetailProps) {
   const {
     consultationId,
-    pet = null,
+    pet: petProp = null,
     extraSections = [],
     extraActions = [],
     onEdit,
@@ -69,6 +70,31 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
   const { consultation, medications, services, loading, error, refetch } =
     useConsultation(consultationId);
   const { settings: consultSettings } = useConsultationsSettings();
+
+  // Fetch de datos de la mascota (solo si no se pasan por prop)
+  const [fetchedPet, setFetchedPet] = useState<PetInfo | null>(null);
+  const petFetchedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (petProp || !consultation?.pet_id || petFetchedRef.current === consultation.pet_id) return;
+    petFetchedRef.current = consultation.pet_id;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const result = await actions.execute<PetInfo>('patients.pets.getById', {
+          id: consultation.pet_id,
+        });
+        if (!cancelled && result) setFetchedPet(result);
+      } catch {
+        // Silencioso — el header muestra fallback sin datos de mascota
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [consultation?.pet_id, petProp]);
+
+  const pet = petProp ?? fetchedPet;
 
   // Contribuciones de otros plugins para la zona de medicamentos
   const { sections: medContributions } = useViewContributions('consultations.detail.open', {
@@ -614,12 +640,12 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
                       React.createElement(
                         UI.TableCell,
                         { className: 'text-right' },
-                        formatCurrency(parseFloat(svc.unit_price))
+                        formatCurrency(parseFloat(svc.unit_price) || 0)
                       ),
                       React.createElement(
                         UI.TableCell,
                         { className: 'text-right font-medium' },
-                        formatCurrency(parseFloat(svc.subtotal))
+                        formatCurrency(parseFloat(svc.subtotal) || 0)
                       )
                     )
                   )

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -1,5 +1,5 @@
 /**
- * Formulario para crear/editar consultas. 6 secciones segun spec.
+ * Formulario para crear/editar consultas con secciones colapsables de datos clínicos.
  */
 import {
   getHostReact,
@@ -281,7 +281,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
         { className: 'flex flex-col gap-3' },
         React.createElement(
           'h3',
-          { className: 'text-sm font-medium text-[var(--cg-text-muted)]' },
+          { className: 'text-sm font-medium text-cg-text-muted' },
           'Datos básicos'
         ),
         React.createElement(
@@ -354,7 +354,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
         { className: 'flex flex-col gap-3' },
         React.createElement(
           'h3',
-          { className: 'text-sm font-medium text-[var(--cg-text-muted)]' },
+          { className: 'text-sm font-medium text-cg-text-muted' },
           'Motivo de consulta'
         ),
         consultSettings.reasonCategoriesEnabled &&
@@ -393,7 +393,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
         { className: 'flex flex-col gap-3' },
         React.createElement(
           'h3',
-          { className: 'text-sm font-medium text-[var(--cg-text-muted)]' },
+          { className: 'text-sm font-medium text-cg-text-muted' },
           'Examen clínico'
         ),
         React.createElement(
@@ -431,7 +431,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
         { className: 'flex flex-col gap-3' },
         React.createElement(
           'h3',
-          { className: 'text-sm font-medium text-[var(--cg-text-muted)]' },
+          { className: 'text-sm font-medium text-cg-text-muted' },
           'Diagnóstico'
         ),
         React.createElement(UI.Textarea, {
@@ -453,7 +453,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
           { className: 'flex flex-col gap-3' },
           React.createElement(
             'h3',
-            { className: 'text-sm font-medium text-[var(--cg-text-muted)]' },
+            { className: 'text-sm font-medium text-cg-text-muted' },
             'Servicios prestados'
           ),
           React.createElement(ServiceLineForm, {
@@ -476,7 +476,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
         { className: 'flex flex-col gap-3' },
         React.createElement(
           'h3',
-          { className: 'text-sm font-medium text-[var(--cg-text-muted)]' },
+          { className: 'text-sm font-medium text-cg-text-muted' },
           'Tratamiento'
         ),
         React.createElement(UI.Textarea, {
@@ -514,7 +514,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
         { className: 'flex flex-col gap-3' },
         React.createElement(
           'h3',
-          { className: 'text-sm font-medium text-[var(--cg-text-muted)]' },
+          { className: 'text-sm font-medium text-cg-text-muted' },
           'Seguimiento'
         ),
         React.createElement(

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -1,8 +1,16 @@
 /**
  * Formulario para crear/editar consultas. 6 secciones segun spec.
  */
-import { getHostReact, getHostUI, usePlugin, useViewContributions } from '@coongro/plugin-sdk';
+import {
+  getHostReact,
+  getHostUI,
+  usePlugin,
+  useViewContributions,
+  actions,
+} from '@coongro/plugin-sdk';
+import type { Product, Category } from '@coongro/products';
 
+import { ROOT_SERVICE_CATEGORY_SLUG } from '../constants/services.js';
 import { useConsultation } from '../hooks/useConsultation.js';
 import { useConsultationMutations } from '../hooks/useConsultationMutations.js';
 import { useConsultationsSettings } from '../hooks/useConsultationsSettings.js';
@@ -15,7 +23,7 @@ import { ServiceLineForm } from './ServiceLineForm.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useState, useCallback, useEffect } = React;
+const { useState, useCallback, useEffect, useRef, useMemo } = React;
 
 export function ConsultationForm(props: ConsultationFormProps) {
   const { consultationId, petId, defaults, onSuccess, onCancel, className = '' } = props;
@@ -48,6 +56,65 @@ export function ConsultationForm(props: ConsultationFormProps) {
   const [notes, setNotes] = useState(defaults?.notes ?? '');
   const [medications, setMedications] = useState<MedicationInput[]>(defaults?.medications ?? []);
   const [serviceLines, setServiceLines] = useState<ServiceLineInput[]>(defaults?.services ?? []);
+
+  // Catálogo de servicios para ServiceLineForm
+  const [serviceCatalog, setServiceCatalog] = useState<Product[]>([]);
+  const [serviceCategories, setServiceCategories] = useState<Category[]>([]);
+  const [catalogLoading, setCatalogLoading] = useState(true);
+  const catalogMountedRef = useRef(true);
+
+  useEffect(() => {
+    catalogMountedRef.current = true;
+    return () => {
+      catalogMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!consultSettings.showPrices) {
+      setCatalogLoading(false);
+      return;
+    }
+    void (async () => {
+      try {
+        const cats = await actions.execute<Category[]>('products.categories.listTree');
+        if (!catalogMountedRef.current) return;
+        setServiceCategories(cats);
+
+        const root = cats.find((c: Category) => c.slug === ROOT_SERVICE_CATEGORY_SLUG);
+        if (!root) {
+          setCatalogLoading(false);
+          return;
+        }
+        const serviceIds = new Set<string>([
+          root.id,
+          ...cats.filter((c: Category) => c.parent_id === root.id).map((c: Category) => c.id),
+        ]);
+
+        const all = await actions.execute<Product[]>('products.items.search', {
+          limit: 300,
+          isActive: true,
+        });
+        if (!catalogMountedRef.current) return;
+        setServiceCatalog(all.filter((p: Product) => serviceIds.has(p.category_id ?? '')));
+      } catch {
+        // Sin catálogo
+      } finally {
+        if (catalogMountedRef.current) setCatalogLoading(false);
+      }
+    })();
+  }, [consultSettings.showPrices]);
+
+  // Subcategorías de servicios para el modal de creación
+  const serviceSubcategories = useMemo(() => {
+    const root = serviceCategories.find((c: Category) => c.slug === ROOT_SERVICE_CATEGORY_SLUG);
+    if (!root) return [];
+    return serviceCategories.filter((c: Category) => c.parent_id === root.id);
+  }, [serviceCategories]);
+
+  const handleProductCreated = useCallback((product: Product) => {
+    setServiceCatalog((prev) => [...prev, product]);
+  }, []);
 
   // Contribuciones de otros plugins (ej: vet-pharmacy inyecta selector de medicamentos)
   const { sections: contributedSections } = useViewContributions('consultations.form.open', {
@@ -392,6 +459,10 @@ export function ConsultationForm(props: ConsultationFormProps) {
           React.createElement(ServiceLineForm, {
             services: serviceLines,
             onChange: setServiceLines,
+            catalog: serviceCatalog,
+            categories: serviceSubcategories,
+            catalogLoading,
+            onProductCreated: handleProductCreated,
           })
         )
       ),

--- a/src/components/ConsultationStats.tsx
+++ b/src/components/ConsultationStats.tsx
@@ -1,6 +1,6 @@
 /**
  * Tarjetas de estadísticas de consultas.
- * Usa StatCard + Skeleton de la librería UI compartida.
+ * Usa StatCard de @coongro/ui-components.
  */
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
@@ -8,13 +8,6 @@ import { useConsultationStats } from '../hooks/useConsultationStats.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-
-interface StatDef {
-  label: string;
-  value: number;
-  icon: string;
-  footer?: string;
-}
 
 export interface ConsultationStatsProps {
   layout?: 'row' | 'grid';
@@ -26,58 +19,46 @@ export function ConsultationStats(props: ConsultationStatsProps) {
 
   const { stats, loading, error } = useConsultationStats();
 
-  if (error) {
-    return React.createElement(UI.ErrorDisplay, {
-      title: 'Error',
-      message: 'Error al cargar estadísticas',
-    });
-  }
+  if (error) return null;
 
-  // Construir las tarjetas de estadísticas a partir de los datos cargados
-  const cards: StatDef[] = stats
-    ? [
-        {
-          label: 'Total',
-          value: stats.total,
-          icon: '📋',
-          footer: 'Consultas registradas',
-        },
-        {
-          label: 'Controles pendientes',
-          value: stats.pendingFollowUps,
-          icon: '🔔',
-          footer: 'Seguimientos programados',
-        },
-      ]
-    : [];
-
-  const gridClass = layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'flex gap-4 overflow-x-auto';
+  const containerClass =
+    layout === 'grid' ? `grid grid-cols-2 gap-4 ${className}` : `flex gap-4 ${className}`;
 
   if (loading) {
     return React.createElement(
       'div',
-      { className: `${gridClass} ${className}` },
+      { className: containerClass },
       Array.from({ length: 2 }).map((_, i) =>
-        React.createElement(UI.Skeleton, {
-          key: i,
-          className: 'flex-1 min-w-[200px] h-[120px] rounded-2xl',
-        })
+        React.createElement(UI.Skeleton, { key: i, className: 'flex-1 h-20 rounded-xl' })
       )
     );
   }
 
+  if (!stats) return null;
+
   return React.createElement(
     'div',
-    { className: `${gridClass} ${className}` },
-    cards.map((card, i) =>
-      React.createElement(UI.StatCard, {
-        key: i,
-        label: card.label,
-        value: card.value,
-        className: 'flex-1 min-w-[200px]',
-        icon: React.createElement('span', { className: 'text-2xl' }, card.icon),
-        footer: card.footer,
-      })
-    )
+    { className: containerClass },
+    React.createElement(UI.StatCard, {
+      size: 'compact',
+      label: 'Consultas registradas',
+      value: stats.total,
+      icon: React.createElement(UI.DynamicIcon, {
+        icon: 'ClipboardList',
+        size: 18,
+        className: 'text-cg-text-muted',
+      }),
+    }),
+    React.createElement(UI.StatCard, {
+      size: 'compact',
+      variant: stats.pendingFollowUps > 0 ? 'warning' : 'default',
+      label: 'Controles pendientes',
+      value: stats.pendingFollowUps,
+      icon: React.createElement(UI.DynamicIcon, {
+        icon: 'Bell',
+        size: 18,
+        className: stats.pendingFollowUps > 0 ? 'text-cg-warning' : 'text-cg-text-muted',
+      }),
+    })
   );
 }

--- a/src/components/ConsultationStats.tsx
+++ b/src/components/ConsultationStats.tsx
@@ -19,7 +19,12 @@ export function ConsultationStats(props: ConsultationStatsProps) {
 
   const { stats, loading, error } = useConsultationStats();
 
-  if (error) return null;
+  if (error) {
+    return React.createElement(UI.ErrorDisplay, {
+      title: 'Error al cargar estadísticas',
+      message: error,
+    });
+  }
 
   const containerClass =
     layout === 'grid' ? `grid grid-cols-2 gap-4 ${className}` : `flex gap-4 ${className}`;

--- a/src/components/ConsultationTimeline.tsx
+++ b/src/components/ConsultationTimeline.tsx
@@ -38,20 +38,20 @@ export function ConsultationTimeline(props: ConsultationTimelineProps) {
   }
 
   if (error) {
-    return React.createElement('p', { className: 'text-sm text-[var(--cg-danger)]' }, error);
+    return React.createElement('p', { className: 'text-sm text-cg-danger' }, error);
   }
 
   return React.createElement(
     'div',
     { className: `flex flex-col gap-3 ${className}` },
 
-    // Header
+    // Encabezado
     React.createElement(
       'div',
       { className: 'flex items-center justify-between' },
       React.createElement(
         'span',
-        { className: 'text-xs text-[var(--cg-text-muted)]' },
+        { className: 'text-xs text-cg-text-muted' },
         total > 0 ? `${total} consulta${total === 1 ? '' : 's'}` : ''
       ),
       showCreateButton &&
@@ -86,17 +86,8 @@ export function ConsultationTimeline(props: ConsultationTimelineProps) {
       consultations.length > 0 &&
       React.createElement(
         UI.Button,
-        {
-          variant: 'link',
-          size: 'sm',
-          onClick: onConsultationClick
-            ? () => {
-                /* Se podria navegar a la lista completa */
-              }
-            : undefined,
-          className: 'self-center',
-        },
-        `Ver las ${total} consultas →`
+        { variant: 'link', size: 'sm', className: 'self-center' },
+        `Ver las ${total} consultas \u2192`
       )
   );
 }

--- a/src/components/ConsultationTimeline.tsx
+++ b/src/components/ConsultationTimeline.tsx
@@ -19,6 +19,7 @@ export function ConsultationTimeline(props: ConsultationTimelineProps) {
     limit = 5,
     totalsMap = {},
     onConsultationClick,
+    onViewAll,
     showCreateButton = false,
     onCreateClick,
     className = '',
@@ -81,12 +82,13 @@ export function ConsultationTimeline(props: ConsultationTimelineProps) {
           })
         ),
 
-    // "Ver mas" si hay mas consultas
+    // "Ver más" si hay más consultas y se provee callback
     total > limit &&
       consultations.length > 0 &&
+      onViewAll &&
       React.createElement(
         UI.Button,
-        { variant: 'link', size: 'sm', className: 'self-center' },
+        { variant: 'link', size: 'sm', className: 'self-center', onClick: onViewAll },
         `Ver las ${total} consultas \u2192`
       )
   );

--- a/src/components/ConsultationTimeline.tsx
+++ b/src/components/ConsultationTimeline.tsx
@@ -2,10 +2,9 @@
  * Timeline cronologico de consultas de una mascota.
  * Componente principal para integracion en la ficha de paciente.
  */
-import { getHostReact, getHostUI, actions } from '@coongro/plugin-sdk';
+import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
 import { useConsultationsByPet } from '../hooks/useConsultationsByPet.js';
-import { useConsultationsSettings } from '../hooks/useConsultationsSettings.js';
 import type { ConsultationTimelineProps } from '../types/components.js';
 import type { Consultation } from '../types/consultation.js';
 
@@ -13,12 +12,12 @@ import { ConsultationCard } from './ConsultationCard.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useState, useEffect, useRef } = React;
 
 export function ConsultationTimeline(props: ConsultationTimelineProps) {
   const {
     petId,
     limit = 5,
+    totalsMap = {},
     onConsultationClick,
     showCreateButton = false,
     onCreateClick,
@@ -29,34 +28,6 @@ export function ConsultationTimeline(props: ConsultationTimelineProps) {
     petId,
     limit,
   });
-  const { settings: consultSettings } = useConsultationsSettings();
-
-  // Cargar totales de servicios para cada consulta
-  const [totalsMap, setTotalsMap] = useState<Record<string, number>>({});
-  const mountedRef = useRef(true);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!consultSettings.showPrices || consultations.length === 0) return;
-    const ids = consultations.map((c: Consultation) => c.id);
-    void (async () => {
-      try {
-        const result = await actions.execute<Record<string, number>>(
-          'consultations.services.totalsByConsultations',
-          { consultationIds: ids }
-        );
-        if (mountedRef.current) setTotalsMap(result ?? {});
-      } catch {
-        // Silenciar - si falla, simplemente no muestra montos
-      }
-    })();
-  }, [consultations, consultSettings.showPrices]);
 
   if (loading) {
     return React.createElement(UI.LoadingOverlay, {
@@ -105,7 +76,7 @@ export function ConsultationTimeline(props: ConsultationTimelineProps) {
           React.createElement(ConsultationCard, {
             key: c.id,
             consultation: c,
-            amount: consultSettings.showPrices ? (totalsMap[c.id] ?? null) : null,
+            amount: totalsMap[c.id] ?? null,
             onClick: onConsultationClick,
           })
         ),

--- a/src/components/PriceInput.tsx
+++ b/src/components/PriceInput.tsx
@@ -1,0 +1,77 @@
+/**
+ * Input de precio con prefijo "$" y sanitización automática.
+ * Reutilizable en ServiceFormDialog, ServiceLineForm y cualquier formulario con precios.
+ */
+import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
+import { sanitizePrice } from '../utils/price.js';
+
+const React = getHostReact();
+const UI = getHostUI();
+const { useCallback } = React;
+
+export interface PriceInputProps {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+  placeholder?: string;
+  hasError?: boolean;
+  errorMessage?: string;
+  disabled?: boolean;
+}
+
+export function PriceInput({
+  id,
+  value,
+  onChange,
+  onBlur,
+  placeholder = '0,00',
+  hasError = false,
+  errorMessage,
+  disabled = false,
+}: PriceInputProps) {
+  const prefixId = id ? `${id}-prefix` : undefined;
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(sanitizePrice(e.target.value));
+    },
+    [onChange]
+  );
+
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement(
+      'div',
+      { className: 'relative' },
+      React.createElement(
+        'span',
+        {
+          id: prefixId,
+          className:
+            'absolute left-3 top-1/2 -translate-y-1/2 text-sm text-cg-text-muted pointer-events-none',
+          'aria-hidden': 'true',
+        },
+        '$'
+      ),
+      React.createElement(UI.Input, {
+        id,
+        type: 'text',
+        inputMode: 'decimal',
+        value,
+        onChange: handleChange,
+        onBlur,
+        placeholder,
+        disabled,
+        className: `pl-7 tabular-nums ${hasError ? 'border-cg-danger' : ''}`,
+        'aria-describedby': prefixId,
+        'aria-invalid': hasError || undefined,
+      })
+    ),
+    hasError &&
+      errorMessage &&
+      React.createElement('p', { className: 'text-xs text-cg-danger', role: 'alert' }, errorMessage)
+  );
+}

--- a/src/components/ServiceFormDialog.tsx
+++ b/src/components/ServiceFormDialog.tsx
@@ -1,0 +1,231 @@
+/**
+ * Dialog reutilizable para crear/editar un servicio veterinario.
+ *
+ * Usado por:
+ * - ServicesView (ABM completo con edición)
+ * - ServiceLineForm (creación rápida desde consulta)
+ */
+import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+import type { Category } from '@coongro/products';
+
+import { isValidPrice } from '../utils/price.js';
+
+import { PriceInput } from './PriceInput.js';
+
+const React = getHostReact();
+const UI = getHostUI();
+const { useState, useCallback, useEffect } = React;
+
+export interface ServiceFormValues {
+  name: string;
+  description: string;
+  categoryId: string;
+  price: string;
+}
+
+interface FormErrors {
+  name?: string;
+  price?: string;
+}
+
+const EMPTY_FORM: ServiceFormValues = {
+  name: '',
+  description: '',
+  categoryId: '',
+  price: '',
+};
+
+function validate(form: ServiceFormValues): FormErrors {
+  const errors: FormErrors = {};
+  if (!form.name.trim()) errors.name = 'El nombre es obligatorio';
+  if (form.price && !isValidPrice(form.price)) errors.price = 'Ingresá un precio válido';
+  return errors;
+}
+
+export interface ServiceFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (values: ServiceFormValues) => Promise<boolean>;
+  /** Valores iniciales para edición. Si es null, es creación. */
+  initialValues?: Partial<ServiceFormValues> | null;
+  categories: Category[];
+  /** Indica si el caller está procesando el guardado. */
+  saving?: boolean;
+  /** Mostrar campo de descripción (default: true). */
+  showDescription?: boolean;
+}
+
+export function ServiceFormDialog({
+  open,
+  onClose,
+  onSave,
+  initialValues = null,
+  categories,
+  saving = false,
+  showDescription = true,
+}: ServiceFormDialogProps) {
+  const isEditing = !!initialValues;
+
+  const [form, setForm] = useState<ServiceFormValues>(() => ({
+    ...EMPTY_FORM,
+    categoryId: categories[0]?.id ?? '',
+    ...initialValues,
+  }));
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    if (open) {
+      setForm({
+        ...EMPTY_FORM,
+        categoryId: categories[0]?.id ?? '',
+        ...initialValues,
+      });
+      setErrors({});
+      setTouched({});
+    }
+  }, [open, initialValues, categories]);
+
+  const handleBlur = useCallback(
+    (field: keyof ServiceFormValues) => {
+      setTouched((prev: Record<string, boolean>) => ({ ...prev, [field]: true }));
+      setErrors(validate(form));
+    },
+    [form]
+  );
+
+  const handleSubmit = useCallback(async () => {
+    const errs = validate(form);
+    setErrors(errs);
+    setTouched({ name: true, price: true });
+    if (Object.keys(errs).length > 0) return;
+
+    const ok = await onSave(form);
+    if (ok) onClose();
+  }, [form, onSave, onClose]);
+
+  const submitLabel = saving ? 'Guardando...' : isEditing ? 'Guardar cambios' : 'Crear servicio';
+
+  return React.createElement(UI.FormDialog, {
+    open,
+    onOpenChange: (o: boolean) => {
+      if (!o) onClose();
+    },
+    title: isEditing ? 'Editar servicio' : 'Nuevo servicio',
+    size: 'sm',
+    footer: React.createElement(
+      React.Fragment,
+      null,
+      React.createElement(
+        UI.Button,
+        { type: 'button', variant: 'outline', onClick: onClose },
+        'Cancelar'
+      ),
+      React.createElement(
+        UI.Button,
+        {
+          type: 'button',
+          onClick: () => {
+            void handleSubmit();
+          },
+          disabled: saving || !form.name.trim(),
+        },
+        submitLabel
+      )
+    ),
+    children: React.createElement(
+      'div',
+      { className: 'flex flex-col gap-4' },
+
+      // Nombre
+      React.createElement(
+        'div',
+        { className: 'flex flex-col gap-1.5' },
+        React.createElement(UI.Label, { htmlFor: 'svc-name' }, 'Nombre *'),
+        React.createElement(UI.Input, {
+          id: 'svc-name',
+          type: 'text',
+          value: form.name,
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+            setForm((prev: ServiceFormValues) => ({ ...prev, name: e.target.value })),
+          onBlur: () => handleBlur('name'),
+          placeholder: 'Ej: Consulta general',
+          maxLength: 200,
+          autoFocus: !isEditing,
+          'aria-invalid': touched.name && !!errors.name,
+          className: touched.name && errors.name ? 'border-cg-danger' : '',
+        }),
+        touched.name &&
+          errors.name &&
+          React.createElement(
+            'p',
+            { className: 'text-xs text-cg-danger', role: 'alert' },
+            errors.name
+          )
+      ),
+
+      // Descripción (opcional, configurable)
+      showDescription &&
+        React.createElement(
+          'div',
+          { className: 'flex flex-col gap-1.5' },
+          React.createElement(UI.Label, { htmlFor: 'svc-desc' }, 'Descripción (opcional)'),
+          React.createElement(UI.Textarea, {
+            id: 'svc-desc',
+            value: form.description,
+            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              setForm((prev: ServiceFormValues) => ({
+                ...prev,
+                description: e.target.value,
+              })),
+            rows: 2,
+            placeholder: 'Ej: Incluye análisis de sangre completo',
+            maxLength: 500,
+          })
+        ),
+
+      // Categoría + Precio
+      React.createElement(
+        'div',
+        { className: 'grid grid-cols-1 sm:grid-cols-2 gap-4' },
+
+        categories.length > 0 &&
+          React.createElement(
+            'div',
+            { className: 'flex flex-col gap-1.5' },
+            React.createElement(UI.Label, { htmlFor: 'svc-cat' }, 'Categoría'),
+            React.createElement(
+              UI.Select,
+              {
+                id: 'svc-cat',
+                value: form.categoryId,
+                onValueChange: (v: string) =>
+                  setForm((prev: ServiceFormValues) => ({
+                    ...prev,
+                    categoryId: v,
+                  })),
+              },
+              categories.map((cat: Category) =>
+                React.createElement(UI.SelectItem, { key: cat.id, value: cat.id }, cat.name)
+              )
+            )
+          ),
+
+        React.createElement(
+          'div',
+          { className: 'flex flex-col gap-1.5' },
+          React.createElement(UI.Label, { htmlFor: 'svc-price' }, 'Precio'),
+          React.createElement(PriceInput, {
+            id: 'svc-price',
+            value: form.price,
+            onChange: (val: string) =>
+              setForm((prev: ServiceFormValues) => ({ ...prev, price: val })),
+            onBlur: () => handleBlur('price'),
+            hasError: !!touched.price && !!errors.price,
+            errorMessage: errors.price,
+          })
+        )
+      )
+    ),
+  });
+}

--- a/src/components/ServiceFormDialog.tsx
+++ b/src/components/ServiceFormDialog.tsx
@@ -193,11 +193,10 @@ export function ServiceFormDialog({
           React.createElement(
             'div',
             { className: 'flex flex-col gap-1.5' },
-            React.createElement(UI.Label, { htmlFor: 'svc-cat' }, 'Categoría'),
+            React.createElement(UI.Label, null, 'Categoría'),
             React.createElement(
               UI.Select,
               {
-                id: 'svc-cat',
                 value: form.categoryId,
                 onValueChange: (v: string) =>
                   setForm((prev: ServiceFormValues) => ({

--- a/src/components/ServiceLineForm.tsx
+++ b/src/components/ServiceLineForm.tsx
@@ -235,7 +235,7 @@ export function ServiceLineForm({
         React.createElement(
           'div',
           {
-            className: 'rounded-md border border-[var(--cg-border)] overflow-hidden',
+            className: 'rounded-md border border-cg-border overflow-hidden',
           },
 
           // Encabezados
@@ -243,7 +243,7 @@ export function ServiceLineForm({
             'div',
             {
               className:
-                'grid grid-cols-[1fr_70px_90px_90px_32px] gap-2 items-center px-3 py-2 bg-[var(--cg-surface-raised)] text-xs font-medium text-[var(--cg-text-muted)] border-b border-[var(--cg-border)]',
+                'grid grid-cols-[1fr_70px_90px_90px_32px] gap-2 items-center px-3 py-2 bg-cg-surface-raised text-xs font-medium text-cg-text-muted border-b border-cg-border',
             },
             React.createElement('span', null, 'Servicio'),
             React.createElement('span', { className: 'text-center' }, 'Cant.'),
@@ -255,7 +255,7 @@ export function ServiceLineForm({
           // Filas
           React.createElement(
             'div',
-            { className: 'divide-y divide-[var(--cg-border)]' },
+            { className: 'divide-y divide-cg-border' },
             services.map((svc: ServiceLineInput, index: number) =>
               React.createElement(
                 'div',
@@ -299,7 +299,7 @@ export function ServiceLineForm({
 
                 React.createElement(
                   'span',
-                  { className: 'text-sm text-right font-medium text-[var(--cg-text)]' },
+                  { className: 'text-sm text-right font-medium text-cg-text' },
                   formatCurrency(parseFloat(svc.subtotal) || 0)
                 ),
 
@@ -324,16 +324,16 @@ export function ServiceLineForm({
             'div',
             {
               className:
-                'flex items-center justify-end gap-3 px-3 py-2.5 border-t border-[var(--cg-border)] bg-[var(--cg-surface-raised)]',
+                'flex items-center justify-end gap-3 px-3 py-2.5 border-t border-cg-border bg-cg-surface-raised',
             },
             React.createElement(
               'span',
-              { className: 'text-sm font-medium text-[var(--cg-text-muted)]' },
+              { className: 'text-sm font-medium text-cg-text-muted' },
               'Total:'
             ),
             React.createElement(
               'span',
-              { className: 'text-base font-bold text-[var(--cg-text)]' },
+              { className: 'text-base font-bold text-cg-text' },
               formatCurrency(total)
             )
           )

--- a/src/components/ServiceLineForm.tsx
+++ b/src/components/ServiceLineForm.tsx
@@ -2,26 +2,23 @@
  * Componente para gestionar líneas de servicios prestados en una consulta.
  *
  * Usa el Combobox de ui-components para buscar en el catálogo de servicios.
- * Si el texto no existe, "Crear '...'" abre un mini-modal que crea el servicio
- * en products y lo agrega a la línea de la consulta.
+ * Si el texto no existe, "Crear '...'" abre un ServiceFormDialog para crear
+ * el servicio y agregarlo a la línea de la consulta.
  */
 import { getHostReact, getHostUI, actions } from '@coongro/plugin-sdk';
 import type { Product, Category } from '@coongro/products';
 
-import { ROOT_SERVICE_CATEGORY_SLUG } from '../constants/services.js';
 import type { ServiceLineInput } from '../types/consultation.js';
+import { createCategoryMap } from '../utils/categories.js';
+import { formatCurrency, formatPrice } from '../utils/price.js';
+
+import { ServiceFormDialog } from './ServiceFormDialog.js';
+import type { ServiceFormValues } from './ServiceFormDialog.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useState, useCallback, useEffect, useMemo, useRef } = React;
+const { useState, useCallback, useMemo } = React;
 
-// Formato de precio para mostrar en catálogo y subtotales
-function formatPrice(price: string | null): string {
-  if (!price || price === '0') return 'Sin precio';
-  return `$${parseFloat(price).toLocaleString('es-AR', { minimumFractionDigits: 2 })}`;
-}
-
-// Construye una línea de servicio a partir de un producto del catálogo
 function buildServiceLine(product: Product): ServiceLineInput {
   return {
     product_id: product.id,
@@ -35,147 +32,14 @@ function buildServiceLine(product: Product): ServiceLineInput {
 export interface ServiceLineFormProps {
   services: ServiceLineInput[];
   onChange: (services: ServiceLineInput[]) => void;
-}
-
-interface CreateServiceModalProps {
-  initialName: string;
-  serviceCategories: Category[];
-  onClose: () => void;
-  onCreated: (product: Product) => void;
-}
-
-function CreateServiceModal({
-  initialName,
-  serviceCategories,
-  onClose,
-  onCreated,
-}: CreateServiceModalProps) {
-  const [name, setName] = useState(initialName);
-  const [categoryId, setCategoryId] = useState(serviceCategories[0]?.id ?? '');
-  const [price, setPrice] = useState('');
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState('');
-
-  const handleSubmit = useCallback(async () => {
-    if (!name.trim()) {
-      setError('El nombre es obligatorio');
-      return;
-    }
-    setSaving(true);
-    setError('');
-    try {
-      const result = await actions.execute<Product[]>('products.items.create', {
-        data: {
-          name: name.trim(),
-          category_id: categoryId || null,
-          sale_price: price || '0',
-          metadata: { type: 'service' },
-        },
-      });
-      const created = Array.isArray(result) ? result[0] : result;
-      if (created) onCreated(created);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'No se pudo crear el servicio');
-    } finally {
-      setSaving(false);
-    }
-  }, [name, categoryId, price, onCreated]);
-
-  return React.createElement(UI.FormDialog, {
-    open: true,
-    onOpenChange: (open: boolean) => {
-      if (!open) onClose();
-    },
-    title: 'Nuevo servicio',
-    size: 'sm',
-    footer: React.createElement(
-      React.Fragment,
-      null,
-      React.createElement(
-        UI.Button,
-        { type: 'button', variant: 'outline', onClick: onClose },
-        'Cancelar'
-      ),
-      React.createElement(
-        UI.Button,
-        {
-          type: 'button',
-          onClick: () => {
-            void handleSubmit();
-          },
-          disabled: saving,
-        },
-        saving ? 'Guardando...' : 'Crear servicio'
-      )
-    ),
-    children: React.createElement(
-      React.Fragment,
-      null,
-
-      error && React.createElement('p', { className: 'text-sm text-[var(--cg-danger)]' }, error),
-
-      // Nombre
-      React.createElement(
-        'div',
-        { className: 'flex flex-col gap-1' },
-        React.createElement(UI.Label, null, 'Nombre *'),
-        React.createElement(UI.Input, {
-          type: 'text',
-          value: name,
-          autoFocus: true,
-          onChange: (e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value),
-          placeholder: 'Ej: Consulta general',
-        })
-      ),
-
-      // Categoría
-      serviceCategories.length > 0 &&
-        React.createElement(
-          'div',
-          { className: 'flex flex-col gap-1' },
-          React.createElement(UI.Label, null, 'Categoría'),
-          React.createElement(
-            UI.Select,
-            {
-              value: categoryId,
-              onValueChange: (v: string) => setCategoryId(v),
-            },
-            React.createElement(UI.SelectItem, { value: '' }, '— Sin categoría —'),
-            serviceCategories.map((cat: Category) =>
-              React.createElement(UI.SelectItem, { key: cat.id, value: cat.id }, cat.name)
-            )
-          )
-        ),
-
-      // Precio
-      React.createElement(
-        'div',
-        { className: 'flex flex-col gap-1' },
-        React.createElement(UI.Label, null, 'Precio'),
-        React.createElement(
-          'div',
-          { className: 'relative' },
-          React.createElement(
-            'span',
-            {
-              className:
-                'absolute left-3 top-1/2 -translate-y-1/2 text-sm text-[var(--cg-text-muted)]',
-            },
-            '$'
-          ),
-          React.createElement(UI.Input, {
-            type: 'number',
-            value: price,
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setPrice(e.target.value),
-            min: '0',
-            step: '0.01',
-            placeholder: '0.00',
-            className: 'pl-7',
-          })
-        )
-      )
-    ),
-  });
+  /** Catálogo de productos/servicios disponibles */
+  catalog: Product[];
+  /** Categorías para el modal de creación de servicio */
+  categories: Category[];
+  /** Indica si el catálogo está cargando */
+  catalogLoading?: boolean;
+  /** Callback cuando se crea un producto nuevo (para que el caller actualice su catálogo) */
+  onProductCreated?: (product: Product) => void;
 }
 
 interface ServiceSearchContentProps {
@@ -202,7 +66,6 @@ function ServiceSearchContent({
       .slice(0, 20);
   }, [catalog, search]);
 
-  // No mostrar "Crear" si el nombre exacto ya existe
   const queryExistsInCatalog = useMemo(() => {
     const q = search.trim().toLowerCase();
     return q.length > 0 && catalog.some((p: Product) => p.name.toLowerCase() === q);
@@ -220,7 +83,6 @@ function ServiceSearchContent({
     UI.ComboboxContent,
     null,
 
-    // Items del catálogo
     filtered.length > 0
       ? filtered.map((p: Product) =>
           React.createElement(
@@ -228,7 +90,10 @@ function ServiceSearchContent({
             {
               key: p.id,
               value: p.id,
-              subtitle: [categoryMap.get(p.category_id ?? '') ?? '', formatPrice(p.sale_price)]
+              subtitle: [
+                categoryMap.get(p.category_id ?? '') ?? '',
+                formatPrice(p.sale_price, 'Sin precio'),
+              ]
                 .filter(Boolean)
                 .join(' · '),
             },
@@ -241,7 +106,6 @@ function ServiceSearchContent({
           search.trim() ? 'Sin resultados' : 'Escribe para buscar en el catálogo'
         ),
 
-    // Opción "Crear" (solo si el nombre no existe ya)
     !queryExistsInCatalog &&
       React.createElement(UI.ComboboxCreate, {
         onCreate: handleCreate,
@@ -250,65 +114,18 @@ function ServiceSearchContent({
   );
 }
 
-export function ServiceLineForm({ services, onChange }: ServiceLineFormProps) {
-  const [catalog, setCatalog] = useState<Product[]>([]);
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [catalogLoading, setCatalogLoading] = useState(true);
+export function ServiceLineForm({
+  services,
+  onChange,
+  catalog,
+  categories,
+  catalogLoading = false,
+  onProductCreated,
+}: ServiceLineFormProps) {
   const [createName, setCreateName] = useState<string | null>(null);
-  const mountedRef = useRef(true);
+  const [saving, setSaving] = useState(false);
 
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
-  // Cargar catálogo de servicios (todas las subcategorías de la raíz)
-  useEffect(() => {
-    void (async () => {
-      try {
-        const cats = await actions.execute<Category[]>('products.categories.listTree');
-        if (!mountedRef.current) return;
-        setCategories(cats);
-
-        const root = cats.find((c: Category) => c.slug === ROOT_SERVICE_CATEGORY_SLUG);
-        if (!root) {
-          setCatalogLoading(false);
-          return;
-        }
-        const serviceIds = new Set<string>([
-          root.id,
-          ...cats.filter((c: Category) => c.parent_id === root.id).map((c: Category) => c.id),
-        ]);
-
-        const all = await actions.execute<Product[]>('products.items.search', {
-          limit: 300,
-          isActive: true,
-        });
-        if (!mountedRef.current) return;
-        setCatalog(all.filter((p: Product) => serviceIds.has(p.category_id ?? '')));
-      } catch {
-        // Sin catálogo
-      } finally {
-        if (mountedRef.current) setCatalogLoading(false);
-      }
-    })();
-  }, []);
-
-  // Subcategorías de servicios para el modal de creación
-  const serviceCategories = useMemo(() => {
-    const root = categories.find((c: Category) => c.slug === ROOT_SERVICE_CATEGORY_SLUG);
-    if (!root) return [];
-    return categories.filter((c: Category) => c.parent_id === root.id);
-  }, [categories]);
-
-  // Mapa categoría id -> nombre
-  const categoryMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const c of categories) map.set(c.id, c.name);
-    return map;
-  }, [categories]);
+  const categoryMap = useMemo(() => createCategoryMap(categories), [categories]);
 
   const handleSelectProduct = useCallback(
     (productId: string) => {
@@ -319,13 +136,32 @@ export function ServiceLineForm({ services, onChange }: ServiceLineFormProps) {
     [catalog, services, onChange]
   );
 
-  const handleServiceCreated = useCallback(
-    (product: Product) => {
-      setCatalog((prev) => [...prev, product]);
-      onChange([...services, buildServiceLine(product)]);
-      setCreateName(null);
+  const handleSaveNewService = useCallback(
+    async (values: ServiceFormValues): Promise<boolean> => {
+      setSaving(true);
+      try {
+        const result = await actions.execute<Product[]>('products.items.create', {
+          data: {
+            name: values.name.trim(),
+            category_id: values.categoryId || null,
+            sale_price: values.price || '0',
+            metadata: { type: 'service' },
+          },
+        });
+        const created = Array.isArray(result) ? result[0] : result;
+        if (created) {
+          onProductCreated?.(created);
+          onChange([...services, buildServiceLine(created)]);
+          return true;
+        }
+      } catch {
+        // El ServiceFormDialog no muestra toast; lo manejamos silenciosamente
+      } finally {
+        setSaving(false);
+      }
+      return false;
     },
-    [services, onChange]
+    [services, onChange, onProductCreated]
   );
 
   const handleRemove = useCallback(
@@ -363,16 +199,18 @@ export function ServiceLineForm({ services, onChange }: ServiceLineFormProps) {
     null,
     React.createElement(
       'div',
-      { className: 'flex flex-col gap-3' },
+      { className: 'flex flex-col gap-4' },
 
-      // Modal de creación (cuando se clickea "Crear '...'")
-      createName !== null &&
-        React.createElement(CreateServiceModal, {
-          initialName: createName,
-          serviceCategories,
-          onClose: () => setCreateName(null),
-          onCreated: handleServiceCreated,
-        }),
+      // Modal de creación via ServiceFormDialog reutilizable
+      React.createElement(ServiceFormDialog, {
+        open: createName !== null,
+        onClose: () => setCreateName(null),
+        onSave: handleSaveNewService,
+        initialValues: createName !== null ? { name: createName } : null,
+        categories,
+        saving,
+        showDescription: false,
+      }),
 
       // Combobox buscador
       React.createElement(
@@ -392,112 +230,112 @@ export function ServiceLineForm({ services, onChange }: ServiceLineFormProps) {
         })
       ),
 
-      // Encabezados (solo si hay líneas)
-      services.length > 0 &&
-        React.createElement(
-          'div',
-          {
-            className:
-              'grid grid-cols-[1fr_70px_90px_90px_32px] gap-2 items-center text-xs text-[var(--cg-text-muted)]',
-          },
-          React.createElement('span', null, 'Servicio'),
-          React.createElement('span', { className: 'text-center' }, 'Cant.'),
-          React.createElement('span', { className: 'text-right' }, 'Precio'),
-          React.createElement('span', { className: 'text-right' }, 'Subtotal'),
-          React.createElement('span', null, '')
-        ),
-
       // Líneas de servicios
       services.length > 0 &&
         React.createElement(
           'div',
-          { className: 'flex flex-col gap-2' },
-          services.map((svc: ServiceLineInput, index: number) =>
-            React.createElement(
-              'div',
-              {
-                key: index,
-                className: 'grid grid-cols-[1fr_70px_90px_90px_32px] gap-2 items-center',
-              },
-
-              // Nombre
-              React.createElement(UI.Input, {
-                type: 'text',
-                value: svc.product_name,
-                onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                  handleChange(index, 'product_name', e.target.value),
-                placeholder: 'Nombre del servicio',
-                readOnly: !!svc.product_id,
-                size: 'sm',
-              }),
-
-              // Cantidad
-              React.createElement(UI.Input, {
-                type: 'number',
-                value: svc.quantity,
-                onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                  handleChange(index, 'quantity', e.target.value),
-                min: '1',
-                step: '1',
-                className: 'text-center',
-                size: 'sm',
-              }),
-
-              // Precio unitario
-              React.createElement(UI.Input, {
-                type: 'number',
-                value: svc.unit_price,
-                onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                  handleChange(index, 'unit_price', e.target.value),
-                min: '0',
-                step: '0.01',
-                className: 'text-right',
-                size: 'sm',
-              }),
-
-              // Subtotal
-              React.createElement(
-                'span',
-                {
-                  className: 'text-sm text-right font-medium text-[var(--cg-text)]',
-                },
-                `$${(parseFloat(svc.subtotal) || 0).toLocaleString('es-AR', { minimumFractionDigits: 2 })}`
-              ),
-
-              // Eliminar
-              React.createElement(UI.Tooltip, {
-                content: 'Eliminar',
-                children: React.createElement(
-                  UI.IconButton,
-                  {
-                    variant: 'danger',
-                    size: 'xs',
-                    onClick: () => handleRemove(index),
-                  },
-                  React.createElement(UI.DynamicIcon, { icon: 'X', size: 16 })
-                ),
-              })
-            )
-          )
-        ),
-
-      // Total
-      services.length > 0 &&
-        React.createElement(
-          'div',
           {
-            className:
-              'flex items-center justify-end gap-3 pt-2 border-t border-[var(--cg-border)]',
+            className: 'rounded-md border border-[var(--cg-border)] overflow-hidden',
           },
+
+          // Encabezados
           React.createElement(
-            'span',
-            { className: 'text-sm font-medium text-[var(--cg-text-muted)]' },
-            'Total:'
+            'div',
+            {
+              className:
+                'grid grid-cols-[1fr_70px_90px_90px_32px] gap-2 items-center px-3 py-2 bg-[var(--cg-surface-raised)] text-xs font-medium text-[var(--cg-text-muted)] border-b border-[var(--cg-border)]',
+            },
+            React.createElement('span', null, 'Servicio'),
+            React.createElement('span', { className: 'text-center' }, 'Cant.'),
+            React.createElement('span', { className: 'text-right' }, 'Precio unit.'),
+            React.createElement('span', { className: 'text-right' }, 'Subtotal'),
+            React.createElement('span', null, '')
           ),
+
+          // Filas
           React.createElement(
-            'span',
-            { className: 'text-base font-bold text-[var(--cg-text)]' },
-            `$${total.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`
+            'div',
+            { className: 'divide-y divide-[var(--cg-border)]' },
+            services.map((svc: ServiceLineInput, index: number) =>
+              React.createElement(
+                'div',
+                {
+                  key: index,
+                  className:
+                    'grid grid-cols-[1fr_70px_90px_90px_32px] gap-2 items-center px-3 py-2',
+                },
+
+                React.createElement(UI.Input, {
+                  type: 'text',
+                  value: svc.product_name,
+                  onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                    handleChange(index, 'product_name', e.target.value),
+                  placeholder: 'Nombre del servicio',
+                  readOnly: !!svc.product_id,
+                  size: 'sm',
+                }),
+
+                React.createElement(UI.Input, {
+                  type: 'number',
+                  value: svc.quantity,
+                  onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                    handleChange(index, 'quantity', e.target.value),
+                  min: '1',
+                  step: '1',
+                  className: 'text-center',
+                  size: 'sm',
+                }),
+
+                React.createElement(UI.Input, {
+                  type: 'number',
+                  value: svc.unit_price,
+                  onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                    handleChange(index, 'unit_price', e.target.value),
+                  min: '0',
+                  step: '0.01',
+                  className: 'text-right',
+                  size: 'sm',
+                }),
+
+                React.createElement(
+                  'span',
+                  { className: 'text-sm text-right font-medium text-[var(--cg-text)]' },
+                  formatCurrency(parseFloat(svc.subtotal) || 0)
+                ),
+
+                React.createElement(UI.Tooltip, {
+                  content: 'Eliminar',
+                  children: React.createElement(
+                    UI.IconButton,
+                    {
+                      variant: 'danger',
+                      size: 'xs',
+                      onClick: () => handleRemove(index),
+                    },
+                    React.createElement(UI.DynamicIcon, { icon: 'X', size: 16 })
+                  ),
+                })
+              )
+            )
+          ),
+
+          // Total
+          React.createElement(
+            'div',
+            {
+              className:
+                'flex items-center justify-end gap-3 px-3 py-2.5 border-t border-[var(--cg-border)] bg-[var(--cg-surface-raised)]',
+            },
+            React.createElement(
+              'span',
+              { className: 'text-sm font-medium text-[var(--cg-text-muted)]' },
+              'Total:'
+            ),
+            React.createElement(
+              'span',
+              { className: 'text-base font-bold text-[var(--cg-text)]' },
+              formatCurrency(total)
+            )
           )
         )
     )

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,3 +4,9 @@ export { ConsultationDetail } from './ConsultationDetail.js';
 export { ConsultationForm } from './ConsultationForm.js';
 export { MedicationList } from './MedicationList.js';
 export { MedicationFormList } from './MedicationFormList.js';
+export { PriceInput, type PriceInputProps } from './PriceInput.js';
+export {
+  ServiceFormDialog,
+  type ServiceFormDialogProps,
+  type ServiceFormValues,
+} from './ServiceFormDialog.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,12 @@ export { MedicationList } from './components/MedicationList.js';
 export { MedicationFormList } from './components/MedicationFormList.js';
 export { ConsultationStats } from './components/ConsultationStats.js';
 export { ServiceLineForm } from './components/ServiceLineForm.js';
+export { PriceInput, type PriceInputProps } from './components/PriceInput.js';
+export {
+  ServiceFormDialog,
+  type ServiceFormDialogProps,
+  type ServiceFormValues,
+} from './components/ServiceFormDialog.js';
 
 // Hooks
 export { useConsultation } from './hooks/useConsultation.js';
@@ -24,7 +30,7 @@ export { useConsultationsByPet } from './hooks/useConsultationsByPet.js';
 export { useConsultationMutations } from './hooks/useConsultationMutations.js';
 export { useConsultationsSettings } from './hooks/useConsultationsSettings.js';
 
-// Types
+// Tipos
 export type {
   Consultation,
   ConsultationMedication,
@@ -47,7 +53,9 @@ export type {
 } from './types/components.js';
 export type { ServiceLineFormProps } from './components/ServiceLineForm.js';
 
-// Utils
+// Utilidades
+export { formatPrice, formatCurrency, sanitizePrice, isValidPrice } from './utils/price.js';
+export { createCategoryMap } from './utils/categories.js';
 export {
   REASON_CATEGORY_LABELS,
   REASON_CATEGORY_EMOJI,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ export { ConsultationDetail } from './components/ConsultationDetail.js';
 export { ConsultationForm } from './components/ConsultationForm.js';
 export { MedicationList } from './components/MedicationList.js';
 export { MedicationFormList } from './components/MedicationFormList.js';
+export { ConsultationStats } from './components/ConsultationStats.js';
+export { ServiceLineForm } from './components/ServiceLineForm.js';
 
 // Hooks
 export { useConsultation } from './hooks/useConsultation.js';
@@ -34,6 +36,7 @@ export type {
 } from './types/consultation.js';
 export type { ConsultationFilters, SortDirection } from './types/filters.js';
 export type {
+  PetInfo,
   ConsultationTimelineProps,
   ConsultationCardProps,
   ConsultationFormProps,
@@ -42,6 +45,7 @@ export type {
   MedicationFormListProps,
   CreateConsultationButtonProps,
 } from './types/components.js';
+export type { ServiceLineFormProps } from './components/ServiceLineForm.js';
 
 // Utils
 export {

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -36,6 +36,8 @@ export interface ConsultationTimelineProps {
   /** Mapa consultationId -> monto total de servicios. Si se omite no muestra montos. */
   totalsMap?: Record<string, number>;
   onConsultationClick?: (consultation: Consultation) => void;
+  /** Callback al presionar "Ver todas". Si se omite, el botón no se muestra. */
+  onViewAll?: () => void;
   showCreateButton?: boolean;
   onCreateClick?: () => void;
   className?: string;
@@ -47,7 +49,6 @@ export interface ConsultationTimelineProps {
 
 export interface ConsultationCardProps {
   consultation: Consultation;
-  showPetName?: boolean;
   amount?: number | null;
   onClick?: (consultation: Consultation) => void;
   actions?: ActionDef<Consultation>[];
@@ -88,7 +89,6 @@ export interface ConsultationDetailProps {
   onEdit?: (consultation: Consultation) => void;
   onDelete?: (consultation: Consultation) => void;
   onBack?: () => void;
-  onNavigate?: (viewId: string, params?: Record<string, unknown>) => void;
   className?: string;
 }
 

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -33,6 +33,8 @@ export interface ColumnDef<T = unknown> {
 export interface ConsultationTimelineProps {
   petId: string;
   limit?: number;
+  /** Mapa consultationId -> monto total de servicios. Si se omite no muestra montos. */
+  totalsMap?: Record<string, number>;
   onConsultationClick?: (consultation: Consultation) => void;
   showCreateButton?: boolean;
   onCreateClick?: () => void;
@@ -69,8 +71,18 @@ export interface ConsultationFormProps {
 // ConsultationDetail
 // ---------------------------------------------------------------------------
 
+export interface PetInfo {
+  name: string;
+  species: string;
+  breed: string | null;
+  birth_date: string | null;
+  sex: string | null;
+}
+
 export interface ConsultationDetailProps {
   consultationId: string;
+  /** Datos de la mascota. Si se omite, el componente no muestra info de mascota. */
+  pet?: PetInfo | null;
   extraSections?: SectionDef[];
   extraActions?: ActionDef<Consultation>[];
   onEdit?: (consultation: Consultation) => void;

--- a/src/utils/categories.ts
+++ b/src/utils/categories.ts
@@ -1,0 +1,8 @@
+import type { Category } from '@coongro/products';
+
+/** Crea un mapa id → name a partir de una lista de categorías. */
+export function createCategoryMap(categories: Category[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const c of categories) map.set(c.id, c.name);
+  return map;
+}

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -1,0 +1,30 @@
+/**
+ * Utilidades compartidas para formato y validación de precios.
+ *
+ * Todos los precios en Coongro se almacenan como strings numéricos
+ * y se formatean en locale es-AR con 2 decimales.
+ */
+
+/** Formatea un string numérico como precio. Retorna placeholder si es nulo/cero/inválido. */
+export function formatPrice(value: string | null, placeholder = '—'): string {
+  if (!value || value === '0') return placeholder;
+  const num = parseFloat(value);
+  return isNaN(num) ? placeholder : formatCurrency(num);
+}
+
+/** Formatea un número como moneda ($X.XXX,XX en es-AR). */
+export function formatCurrency(amount: number): string {
+  return `$${amount.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`;
+}
+
+/** Filtra caracteres no numéricos de un input de precio (solo dígitos y un punto). */
+export function sanitizePrice(value: string): string {
+  return value.replace(/[^\d.]/g, '').replace(/(\..*?)\..*/g, '$1');
+}
+
+/** Valida que un string sea un precio válido (vacío, o número >= 0). */
+export function isValidPrice(value: string): boolean {
+  if (!value) return true;
+  const num = parseFloat(value);
+  return !isNaN(num) && num >= 0;
+}

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -17,7 +17,7 @@ export function formatCurrency(amount: number): string {
   return `$${amount.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`;
 }
 
-/** Filtra caracteres no numéricos de un input de precio (solo dígitos y un punto). */
+/** Filtra caracteres no numéricos de un input de precio. Permite solo dígitos y un único punto decimal. */
 export function sanitizePrice(value: string): string {
   return value.replace(/[^\d.]/g, '').replace(/(\..*?)\..*/g, '$1');
 }

--- a/src/views/consultation-detail/index.tsx
+++ b/src/views/consultation-detail/index.tsx
@@ -1,16 +1,18 @@
 /**
  * Vista de detalle de una consulta.
  */
-import { getHostReact, getHostUI, usePlugin } from '@coongro/plugin-sdk';
+import { getHostReact, getHostUI, usePlugin, actions } from '@coongro/plugin-sdk';
 
 import { ConsultationDetail } from '../../components/ConsultationDetail.js';
 import { ConsultationForm } from '../../components/ConsultationForm.js';
+import { useConsultation } from '../../hooks/useConsultation.js';
 import { useConsultationMutations } from '../../hooks/useConsultationMutations.js';
+import type { PetInfo } from '../../types/components.js';
 import type { Consultation } from '../../types/consultation.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useState, useCallback } = React;
+const { useState, useCallback, useEffect, useRef } = React;
 
 export function ConsultationDetailView(props: { consultationId?: string }) {
   const { views, toast } = usePlugin();
@@ -20,6 +22,30 @@ export function ConsultationDetailView(props: { consultationId?: string }) {
   const [showEditModal, setShowEditModal] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
   const { softDelete } = useConsultationMutations();
+
+  // Fetch de datos de mascota para pasar al detail
+  const { consultation } = useConsultation(consultationId ?? '');
+  const [pet, setPet] = useState<PetInfo | null>(null);
+  const petFetchedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!consultation?.pet_id || petFetchedRef.current === consultation.pet_id) return;
+    petFetchedRef.current = consultation.pet_id;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const result = await actions.execute<PetInfo>('patients.pets.getById', {
+          id: consultation.pet_id,
+        });
+        if (!cancelled && result) setPet(result);
+      } catch {
+        // Silencioso
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [consultation?.pet_id]);
 
   const handleBack = useCallback(() => {
     views.open('consultations.list.open');
@@ -68,6 +94,7 @@ export function ConsultationDetailView(props: { consultationId?: string }) {
       React.createElement(ConsultationDetail, {
         key: refreshKey,
         consultationId,
+        pet,
         onBack: handleBack,
         onEdit: handleEdit,
         onDelete: handleDelete,

--- a/src/views/consultation-detail/index.tsx
+++ b/src/views/consultation-detail/index.tsx
@@ -1,18 +1,16 @@
 /**
  * Vista de detalle de una consulta.
  */
-import { getHostReact, getHostUI, usePlugin, actions } from '@coongro/plugin-sdk';
+import { getHostReact, getHostUI, usePlugin } from '@coongro/plugin-sdk';
 
 import { ConsultationDetail } from '../../components/ConsultationDetail.js';
 import { ConsultationForm } from '../../components/ConsultationForm.js';
-import { useConsultation } from '../../hooks/useConsultation.js';
 import { useConsultationMutations } from '../../hooks/useConsultationMutations.js';
-import type { PetInfo } from '../../types/components.js';
 import type { Consultation } from '../../types/consultation.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useState, useCallback, useEffect, useRef } = React;
+const { useState, useCallback } = React;
 
 export function ConsultationDetailView(props: { consultationId?: string }) {
   const { views, toast } = usePlugin();
@@ -22,30 +20,6 @@ export function ConsultationDetailView(props: { consultationId?: string }) {
   const [showEditModal, setShowEditModal] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
   const { softDelete } = useConsultationMutations();
-
-  // Fetch de datos de mascota para pasar al detail
-  const { consultation } = useConsultation(consultationId ?? '');
-  const [pet, setPet] = useState<PetInfo | null>(null);
-  const petFetchedRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    if (!consultation?.pet_id || petFetchedRef.current === consultation.pet_id) return;
-    petFetchedRef.current = consultation.pet_id;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const result = await actions.execute<PetInfo>('patients.pets.getById', {
-          id: consultation.pet_id,
-        });
-        if (!cancelled && result) setPet(result);
-      } catch {
-        // Silencioso
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [consultation?.pet_id]);
 
   const handleBack = useCallback(() => {
     views.open('consultations.list.open');
@@ -71,13 +45,6 @@ export function ConsultationDetailView(props: { consultationId?: string }) {
     [softDelete, views]
   );
 
-  const handleNavigate = useCallback(
-    (viewId: string, params?: Record<string, unknown>) => {
-      views.open(viewId, params);
-    },
-    [views]
-  );
-
   if (!consultationId) {
     return React.createElement(UI.EmptyState, {
       title: 'No se especificó una consulta',
@@ -94,11 +61,9 @@ export function ConsultationDetailView(props: { consultationId?: string }) {
       React.createElement(ConsultationDetail, {
         key: refreshKey,
         consultationId,
-        pet,
         onBack: handleBack,
         onEdit: handleEdit,
         onDelete: handleDelete,
-        onNavigate: handleNavigate,
       })
     ),
 

--- a/src/views/consultation-detail/index.tsx
+++ b/src/views/consultation-detail/index.tsx
@@ -64,7 +64,7 @@ export function ConsultationDetailView(props: { consultationId?: string }) {
     { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
     React.createElement(
       'div',
-      { className: 'max-w-6xl mx-auto' },
+      { className: 'w-full' },
       React.createElement(ConsultationDetail, {
         key: refreshKey,
         consultationId,

--- a/src/views/consultation-form/index.tsx
+++ b/src/views/consultation-form/index.tsx
@@ -37,21 +37,21 @@ export function ConsultationFormView(props: { petId?: string; consultationId?: s
 
   return React.createElement(
     'div',
-    { className: 'font-inter min-h-screen bg-[var(--cg-bg-secondary)] p-6' },
+    { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
     React.createElement(
       'div',
-      { className: 'max-w-2xl mx-auto' },
+      { className: 'max-w-6xl mx-auto' },
       React.createElement(
         'div',
         { className: 'mb-6' },
         React.createElement(
           'h1',
-          { className: 'text-2xl font-bold text-[var(--cg-text)]' },
+          { className: 'text-2xl font-bold text-cg-text' },
           isEditing ? 'Editar consulta' : 'Nueva consulta'
         ),
         React.createElement(
           'p',
-          { className: 'text-sm text-[var(--cg-text-muted)] mt-1' },
+          { className: 'text-sm text-cg-text-muted mt-1' },
           isEditing ? 'Modificar datos de la consulta' : 'Registrar una nueva consulta veterinaria'
         )
       ),

--- a/src/views/consultation-form/index.tsx
+++ b/src/views/consultation-form/index.tsx
@@ -40,7 +40,7 @@ export function ConsultationFormView(props: { petId?: string; consultationId?: s
     { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
     React.createElement(
       'div',
-      { className: 'max-w-6xl mx-auto' },
+      { className: 'w-full' },
       React.createElement(
         'div',
         { className: 'mb-6' },

--- a/src/views/consultations-list/index.tsx
+++ b/src/views/consultations-list/index.tsx
@@ -344,11 +344,8 @@ export function ConsultationsListView() {
     return consultations.map(renderConsultationRow);
   }
 
-  // Ya no se usa el early return para empty state prístino.
-  // La estructura completa (stats, filtros, tabla) se muestra siempre,
-  // y el empty state mejorado vive dentro de la tabla.
-
-  // ── Vista normal: con datos o con filtros activos ──
+  // La estructura completa (stats, filtros, tabla) se muestra siempre;
+  // el empty state se renderiza dentro de la tabla.
   return React.createElement(
     'div',
     { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
@@ -469,7 +466,7 @@ export function ConsultationsListView() {
           React.createElement(
             UI.Table,
             { className: 'table-fixed w-full' },
-            // Header
+            // Encabezado
             React.createElement(
               UI.TableHeader,
               null,
@@ -508,7 +505,7 @@ export function ConsultationsListView() {
               )
             ),
 
-            // Body
+            // Cuerpo
             React.createElement(UI.TableBody, null, renderTableBodyContent())
           ),
 

--- a/src/views/consultations-list/index.tsx
+++ b/src/views/consultations-list/index.tsx
@@ -188,7 +188,10 @@ export function ConsultationsListView() {
 
   const hasFilters = localSearch || filters.reasonCategory || filters.dateFrom || filters.dateTo;
 
-  const COL_COUNT = 7; // Fecha, Paciente, Veterinario, Motivo, Categoria, Diagnostico, Acciones
+  // Estado para abrir el formulario desde el empty state
+  const [emptyStateCreateOpen, setEmptyStateCreateOpen] = useState(false);
+
+  const COL_COUNT = 5; // Fecha, Paciente, Veterinario, Motivo+Diagnóstico, Categoría
 
   /** Renderiza una fila de consulta con datos de mascota resueltos */
   function renderConsultationRow(c: Consultation) {
@@ -219,7 +222,26 @@ export function ConsultationsListView() {
         )
       ),
       React.createElement(UI.TableCell, null, c.vet_name),
-      React.createElement(UI.TableCell, { className: 'max-w-[200px] truncate' }, c.reason),
+      // Motivo + Diagnóstico combinados
+      React.createElement(
+        UI.TableCell,
+        null,
+        React.createElement(
+          'div',
+          { className: 'flex flex-col gap-0.5 min-w-0' },
+          React.createElement(
+            'span',
+            { className: 'text-sm font-medium text-cg-text truncate block' },
+            c.reason
+          ),
+          c.diagnosis &&
+            React.createElement(
+              'span',
+              { className: 'text-xs text-cg-text-muted truncate block' },
+              c.diagnosis
+            )
+        )
+      ),
       React.createElement(
         UI.TableCell,
         null,
@@ -233,27 +255,6 @@ export function ConsultationsListView() {
               formatReasonCategory(c.reason_category)
             )
           : '—'
-      ),
-      React.createElement(
-        UI.TableCell,
-        { className: 'max-w-[200px] truncate' },
-        c.diagnosis ?? '—'
-      ),
-      React.createElement(
-        UI.TableCell,
-        {
-          className: 'text-right',
-          onClick: (e: { stopPropagation: () => void }) => e.stopPropagation(),
-        },
-        React.createElement(
-          UI.Button,
-          {
-            variant: 'ghost',
-            size: 'xs',
-            onClick: () => handleConsultationClick(c),
-          },
-          'Ver'
-        )
       )
     );
   }
@@ -301,11 +302,41 @@ export function ConsultationsListView() {
         React.createElement(
           UI.TableCell,
           { colSpan: COL_COUNT, className: 'p-0' },
-          React.createElement(UI.EmptyState, {
-            title: hasFilters
-              ? 'No se encontraron consultas con esos filtros'
-              : 'Sin consultas registradas',
-          })
+          hasFilters
+            ? React.createElement(UI.EmptyState, {
+                icon: React.createElement(UI.DynamicIcon, {
+                  icon: 'SearchX',
+                  size: 24,
+                  className: 'text-cg-text-muted',
+                }),
+                title: 'No se encontraron consultas',
+                description: 'Probá ajustando los filtros o limpiando la búsqueda.',
+                action: React.createElement(
+                  UI.Button,
+                  { variant: 'outline', size: 'sm', onClick: handleClearFilters },
+                  'Limpiar filtros'
+                ),
+              })
+            : React.createElement(UI.EmptyState, {
+                icon: React.createElement(UI.DynamicIcon, {
+                  icon: 'ClipboardList',
+                  size: 24,
+                  className: 'text-cg-text-muted',
+                }),
+                title: 'Sin consultas registradas',
+                description:
+                  'Registrá la primera consulta de un paciente para comenzar a construir su historial clínico.',
+                action: React.createElement(
+                  UI.Button,
+                  {
+                    variant: 'brand',
+                    onClick: () => setEmptyStateCreateOpen(true),
+                    className: 'gap-2',
+                  },
+                  React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 18 }),
+                  'Nueva consulta'
+                ),
+              })
         )
       );
     }
@@ -313,6 +344,11 @@ export function ConsultationsListView() {
     return consultations.map(renderConsultationRow);
   }
 
+  // Ya no se usa el early return para empty state prístino.
+  // La estructura completa (stats, filtros, tabla) se muestra siempre,
+  // y el empty state mejorado vive dentro de la tabla.
+
+  // ── Vista normal: con datos o con filtros activos ──
   return React.createElement(
     'div',
     { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
@@ -320,24 +356,12 @@ export function ConsultationsListView() {
       'div',
       { className: 'w-full flex flex-col gap-6' },
 
-      // ── Header ──
-      React.createElement(
-        'div',
-        { className: 'flex items-center justify-between' },
-        React.createElement(
-          'div',
-          null,
-          React.createElement('h1', { className: 'text-2xl font-bold text-cg-text' }, 'Consultas'),
-          React.createElement(
-            'p',
-            { className: 'text-sm text-cg-text-muted mt-1' },
-            'Historial de consultas veterinarias'
-          )
-        ),
-        React.createElement(CreateConsultationButton, {
+      React.createElement(UI.PageHeader, {
+        title: 'Consultas',
+        action: React.createElement(CreateConsultationButton, {
           onSuccess: handleCreateSuccess,
-        })
-      ),
+        }),
+      }),
 
       // ── Stats ──
       React.createElement(ConsultationStats, { layout: 'row' }),
@@ -350,92 +374,101 @@ export function ConsultationsListView() {
           'div',
           { className: 'flex flex-col gap-4' },
 
-          // Búsqueda con icono
+          // Filtros: búsqueda + categorías + fechas
           React.createElement(
             'div',
-            { className: 'relative flex-1' },
-            React.createElement(UI.DynamicIcon, {
-              icon: 'Search',
-              size: 16,
-              className: 'absolute left-3 top-1/2 -translate-y-1/2 text-cg-text-muted',
-            }),
-            React.createElement(UI.Input, {
-              type: 'text',
-              placeholder: 'Buscar por motivo, veterinario, diagnóstico...',
-              value: localSearch,
-              onChange: handleSearchChange,
-              className: 'pl-10',
-            })
-          ),
+            { className: 'flex flex-wrap items-end justify-between gap-4' },
 
-          // Filtros: categorías + fechas
-          React.createElement(
-            'div',
-            { className: 'flex items-center gap-4 flex-wrap' },
+            // Izquierda: búsqueda + categorías
+            React.createElement(
+              'div',
+              { className: 'flex items-end gap-3 min-w-0 flex-1' },
 
-            // Categorías rápidas
-            consultSettings.reasonCategoriesEnabled &&
-              React.createElement(UI.ButtonGroup, null, [
-                React.createElement(
-                  UI.ButtonGroupItem,
-                  {
-                    key: '__all',
-                    active: !filters.reasonCategory,
-                    onClick: () => setFilters({ ...filters, reasonCategory: undefined }),
-                  },
-                  'Todas'
-                ),
-                ...ALL_REASON_CATEGORIES.map((cat) =>
+              React.createElement(UI.SearchInput, {
+                placeholder: 'Buscar...',
+                value: localSearch,
+                onChange: handleSearchChange,
+                className: 'w-56 shrink-0',
+              }),
+              consultSettings.reasonCategoriesEnabled &&
+                React.createElement(UI.ButtonGroup, null, [
                   React.createElement(
                     UI.ButtonGroupItem,
                     {
-                      key: cat,
-                      active: filters.reasonCategory === cat,
-                      onClick: () => handleCategoryFilter(cat),
+                      key: '__all',
+                      active: !filters.reasonCategory,
+                      onClick: () => setFilters({ ...filters, reasonCategory: undefined }),
                     },
-                    REASON_CATEGORY_LABELS[cat] ?? cat
-                  )
-                ),
-              ]),
-
-            // Fechas
-            React.createElement(
-              'div',
-              { className: 'flex items-center gap-2 ml-auto' },
-              React.createElement(UI.Input, {
-                type: 'date',
-                value: filters.dateFrom ?? '',
-                onChange: handleDateFrom,
-                title: 'Desde',
-                className: 'w-36',
-              }),
-              React.createElement('span', { className: 'text-cg-text-muted text-sm' }, '—'),
-              React.createElement(UI.Input, {
-                type: 'date',
-                value: filters.dateTo ?? '',
-                onChange: handleDateTo,
-                title: 'Hasta',
-                className: 'w-36',
-              })
+                    'Todas'
+                  ),
+                  ...ALL_REASON_CATEGORIES.map((cat) =>
+                    React.createElement(
+                      UI.ButtonGroupItem,
+                      {
+                        key: cat,
+                        active: filters.reasonCategory === cat,
+                        onClick: () => handleCategoryFilter(cat),
+                      },
+                      REASON_CATEGORY_LABELS[cat] ?? cat
+                    )
+                  ),
+                ]),
+              hasFilters &&
+                React.createElement(
+                  UI.Button,
+                  {
+                    variant: 'link',
+                    size: 'xs',
+                    onClick: handleClearFilters,
+                  },
+                  'Limpiar filtros'
+                )
             ),
 
-            // Limpiar filtros
-            hasFilters &&
+            // Fechas (derecha, agrupadas visualmente)
+            React.createElement(
+              'div',
+              {
+                className: 'flex items-end gap-2 shrink-0 bg-cg-bg-secondary rounded-lg px-3 py-2',
+              },
               React.createElement(
-                UI.Button,
-                {
-                  variant: 'link',
-                  size: 'xs',
-                  onClick: handleClearFilters,
-                },
-                'Limpiar filtros'
+                'div',
+                { className: 'flex flex-col gap-0.5' },
+                React.createElement(
+                  'span',
+                  { className: 'text-xs font-medium text-cg-text-muted' },
+                  'Desde'
+                ),
+                React.createElement(UI.Input, {
+                  type: 'date',
+                  value: filters.dateFrom ?? '',
+                  onChange: handleDateFrom,
+                  className: 'w-40',
+                })
+              ),
+              React.createElement('span', { className: 'text-cg-text-muted text-sm pb-2.5' }, '—'),
+              React.createElement(
+                'div',
+                { className: 'flex flex-col gap-0.5' },
+                React.createElement(
+                  'span',
+                  { className: 'text-xs font-medium text-cg-text-muted' },
+                  'Hasta'
+                ),
+                React.createElement(UI.Input, {
+                  type: 'date',
+                  value: filters.dateTo ?? '',
+                  onChange: handleDateTo,
+                  className: 'w-40',
+                })
               )
+            )
           ),
 
           // ── Tabla ──
           React.createElement(
             UI.Table,
-            null,
+            { className: 'table-fixed w-full' },
             // Header
             React.createElement(
               UI.TableHeader,
@@ -445,29 +478,33 @@ export function ConsultationsListView() {
                 null,
                 React.createElement(
                   UI.TableHead,
-                  { sortDirection: getSortDirection('date'), onSort: () => handleSort('date') },
+                  {
+                    className: 'w-28',
+                    sortDirection: getSortDirection('date'),
+                    onSort: () => handleSort('date'),
+                  },
                   'Fecha'
                 ),
-                React.createElement(UI.TableHead, null, 'Paciente'),
+                React.createElement(UI.TableHead, { className: 'w-36' }, 'Paciente'),
                 React.createElement(
                   UI.TableHead,
                   {
+                    className: 'w-40',
                     sortDirection: getSortDirection('vet_name'),
                     onSort: () => handleSort('vet_name'),
                   },
                   'Veterinario'
                 ),
-                React.createElement(UI.TableHead, null, 'Motivo'),
+                React.createElement(UI.TableHead, null, 'Motivo / Diagnóstico'),
                 React.createElement(
                   UI.TableHead,
                   {
+                    className: 'w-40',
                     sortDirection: getSortDirection('reason_category'),
                     onSort: () => handleSort('reason_category'),
                   },
                   'Categoría'
-                ),
-                React.createElement(UI.TableHead, null, 'Diagnóstico'),
-                React.createElement(UI.TableHead, { className: 'w-20 text-right' }, 'Acciones')
+                )
               )
             ),
 
@@ -530,7 +567,14 @@ export function ConsultationsListView() {
               )
             )
         )
-      )
+      ),
+
+      // CreateConsultationButton controlado para el CTA del empty state
+      React.createElement(CreateConsultationButton, {
+        open: emptyStateCreateOpen,
+        onOpenChange: setEmptyStateCreateOpen,
+        onSuccess: handleCreateSuccess,
+      })
     )
   );
 }

--- a/src/views/consultations-list/index.tsx
+++ b/src/views/consultations-list/index.tsx
@@ -318,7 +318,7 @@ export function ConsultationsListView() {
     { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
     React.createElement(
       'div',
-      { className: 'max-w-6xl mx-auto flex flex-col gap-6' },
+      { className: 'w-full flex flex-col gap-6' },
 
       // ── Header ──
       React.createElement(

--- a/src/views/detail-override/index.tsx
+++ b/src/views/detail-override/index.tsx
@@ -4,15 +4,17 @@
 
 import { PetDetail, PetForm } from '@coongro/patients';
 import type { Pet } from '@coongro/patients';
-import { getHostReact, getHostUI, usePlugin } from '@coongro/plugin-sdk';
+import { getHostReact, getHostUI, usePlugin, actions } from '@coongro/plugin-sdk';
 
 import { ConsultationTimeline } from '../../components/ConsultationTimeline.js';
 import { CreateConsultationButton } from '../../components/CreateConsultationButton.js';
+import { useConsultationsByPet } from '../../hooks/useConsultationsByPet.js';
+import { useConsultationsSettings } from '../../hooks/useConsultationsSettings.js';
 import type { Consultation } from '../../types/consultation.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useCallback, useState } = React;
+const { useCallback, useState, useEffect, useRef } = React;
 
 export function DetailOverrideView(props: { petId?: string }) {
   const { views, toast } = usePlugin();
@@ -21,6 +23,35 @@ export function DetailOverrideView(props: { petId?: string }) {
   const [showEditModal, setShowEditModal] = useState(false);
   const [showConsultationModal, setShowConsultationModal] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+
+  // Fetch de totales de servicios para pasar al timeline
+  const { settings: consultSettings } = useConsultationsSettings();
+  const { consultations: timelineConsultations } = useConsultationsByPet({ petId, limit: 5 });
+  const [totalsMap, setTotalsMap] = useState<Record<string, number>>({});
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!consultSettings.showPrices || timelineConsultations.length === 0) return;
+    const ids = timelineConsultations.map((c: Consultation) => c.id);
+    void (async () => {
+      try {
+        const result = await actions.execute<Record<string, number>>(
+          'consultations.services.totalsByConsultations',
+          { consultationIds: ids }
+        );
+        if (mountedRef.current) setTotalsMap(result ?? {});
+      } catch {
+        // Silencioso
+      }
+    })();
+  }, [timelineConsultations, consultSettings.showPrices]);
 
   const handleBack = useCallback(() => {
     views.open('patients.list.open');
@@ -74,6 +105,7 @@ export function DetailOverrideView(props: { petId?: string }) {
         React.createElement(ConsultationTimeline, {
           petId,
           limit: 5,
+          totalsMap,
           onConsultationClick: (c: Consultation) =>
             views.open('consultations.detail.open', { consultationId: c.id }),
         }),

--- a/src/views/detail-override/index.tsx
+++ b/src/views/detail-override/index.tsx
@@ -93,7 +93,7 @@ export function DetailOverrideView(props: { petId?: string }) {
     { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
     React.createElement(
       'div',
-      { className: 'max-w-6xl mx-auto' },
+      { className: 'w-full' },
       React.createElement(PetDetail, {
         key: refreshKey,
         petId,

--- a/src/views/detail-override/index.tsx
+++ b/src/views/detail-override/index.tsx
@@ -1,5 +1,5 @@
-// --- View Override ---
-// Overrides: patients.detail.open (from plugin: patients)
+// --- Override de Vista ---
+// Reemplaza: patients.detail.open (del plugin: patients)
 // Importa PetDetail de @coongro/patients y agrega extraSections/extraActions de consultas.
 
 import { PetDetail, PetForm } from '@coongro/patients';

--- a/src/views/detail-override/index.tsx
+++ b/src/views/detail-override/index.tsx
@@ -90,10 +90,10 @@ export function DetailOverrideView(props: { petId?: string }) {
 
   return React.createElement(
     'div',
-    { className: 'font-inter min-h-screen bg-[var(--cg-bg-secondary)] p-6' },
+    { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
     React.createElement(
       'div',
-      { className: 'max-w-3xl mx-auto' },
+      { className: 'max-w-6xl mx-auto' },
       React.createElement(PetDetail, {
         key: refreshKey,
         petId,

--- a/src/views/detail-override/index.tsx
+++ b/src/views/detail-override/index.tsx
@@ -108,6 +108,7 @@ export function DetailOverrideView(props: { petId?: string }) {
           totalsMap,
           onConsultationClick: (c: Consultation) =>
             views.open('consultations.detail.open', { consultationId: c.id }),
+          onViewAll: () => views.open('consultations.list.open'),
         }),
     },
   ];

--- a/src/views/services/index.tsx
+++ b/src/views/services/index.tsx
@@ -281,11 +281,57 @@ export function ServicesView() {
 
   function renderTableContent(): ReturnType<typeof React.createElement> {
     if (loading) {
-      return React.createElement(UI.LoadingOverlay, {
-        variant: 'skeleton',
-        rows: 5,
-        className: 'p-6',
-      });
+      return React.createElement(
+        UI.Table,
+        { className: 'table-fixed w-full' },
+        React.createElement(
+          UI.TableHeader,
+          null,
+          React.createElement(
+            UI.TableRow,
+            null,
+            React.createElement(UI.TableHead, { className: 'w-auto' }, 'Servicio'),
+            React.createElement(
+              UI.TableHead,
+              { className: 'w-36 hidden sm:table-cell' },
+              'Categoría'
+            ),
+            React.createElement(UI.TableHead, { className: 'w-28 text-right' }, 'Precio'),
+            React.createElement(UI.TableHead, { className: 'w-20' }, '')
+          )
+        ),
+        React.createElement(
+          UI.TableBody,
+          null,
+          Array.from({ length: 5 }).map((_, i) =>
+            React.createElement(
+              UI.TableRow,
+              { key: i },
+              React.createElement(
+                UI.TableCell,
+                null,
+                React.createElement(
+                  'div',
+                  { className: 'flex flex-col gap-1' },
+                  React.createElement(UI.Skeleton, { className: 'h-4 w-40 rounded' }),
+                  React.createElement(UI.Skeleton, { className: 'h-3 w-24 rounded' })
+                )
+              ),
+              React.createElement(
+                UI.TableCell,
+                { className: 'hidden sm:table-cell' },
+                React.createElement(UI.Skeleton, { className: 'h-5 w-20 rounded-full' })
+              ),
+              React.createElement(
+                UI.TableCell,
+                { className: 'text-right' },
+                React.createElement(UI.Skeleton, { className: 'h-4 w-16 rounded ml-auto' })
+              ),
+              React.createElement(UI.TableCell, null)
+            )
+          )
+        )
+      );
     }
     if (prodsError) {
       return React.createElement(UI.ErrorDisplay, {

--- a/src/views/services/index.tsx
+++ b/src/views/services/index.tsx
@@ -9,39 +9,79 @@ import { getHostReact, getHostUI, usePlugin } from '@coongro/plugin-sdk';
 import type { Product, Category, ProductCreateData } from '@coongro/products';
 import { useProducts, useCategories, useProductMutations } from '@coongro/products';
 
+import { ServiceFormDialog } from '../../components/ServiceFormDialog.js';
+import type { ServiceFormValues } from '../../components/ServiceFormDialog.js';
 import { ROOT_SERVICE_CATEGORY_SLUG } from '../../constants/services.js';
+import { createCategoryMap } from '../../utils/categories.js';
+import { formatPrice } from '../../utils/price.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useState, useCallback, useEffect, useMemo } = React;
-
-interface ServiceFormData {
-  name: string;
-  description: string;
-  categoryId: string;
-  price: string;
-}
-
-const EMPTY_FORM: ServiceFormData = {
-  name: '',
-  description: '',
-  categoryId: '',
-  price: '',
-};
+const { useState, useCallback, useEffect, useMemo, useRef } = React;
 
 type SortField = 'name' | 'price';
 type SortDir = 'asc' | 'desc' | false;
 
-function formatPrice(value: string | null): string {
-  if (!value || value === '0') return '';
-  const num = parseFloat(value);
-  return isNaN(num) ? '' : `$${num.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`;
+function buildPageLinks(
+  currentPage: number,
+  totalPages: number,
+  setPage: (page: number) => void
+): ReturnType<typeof React.createElement>[] {
+  const pages: ReturnType<typeof React.createElement>[] = [];
+  let start = Math.max(1, currentPage - 2);
+  const end = Math.min(totalPages, start + 4);
+  start = Math.max(1, end - 4);
+
+  if (start > 1) {
+    pages.push(
+      React.createElement(
+        UI.PaginationItem,
+        { key: 1 },
+        React.createElement(UI.PaginationLink, {
+          onClick: () => setPage(1),
+          isActive: currentPage === 1,
+          children: '1',
+        })
+      )
+    );
+    if (start > 2) pages.push(React.createElement(UI.PaginationEllipsis, { key: 'e1' }));
+  }
+
+  for (let i = start; i <= end; i++) {
+    pages.push(
+      React.createElement(
+        UI.PaginationItem,
+        { key: i },
+        React.createElement(UI.PaginationLink, {
+          onClick: () => setPage(i),
+          isActive: currentPage === i,
+          children: String(i),
+        })
+      )
+    );
+  }
+
+  if (end < totalPages) {
+    if (end < totalPages - 1) pages.push(React.createElement(UI.PaginationEllipsis, { key: 'e2' }));
+    pages.push(
+      React.createElement(
+        UI.PaginationItem,
+        { key: totalPages },
+        React.createElement(UI.PaginationLink, {
+          onClick: () => setPage(totalPages),
+          isActive: currentPage === totalPages,
+          children: String(totalPages),
+        })
+      )
+    );
+  }
+
+  return pages;
 }
 
 export function ServicesView() {
   const { toast } = usePlugin();
 
-  // --- Categorías ---
   const { categories, loading: catsLoading } = useCategories();
 
   const rootCategory = useMemo(
@@ -61,28 +101,31 @@ export function ServicesView() {
     [serviceCategories]
   );
 
-  // --- Filtro de subcategoría ---
-  const [activeCatId, setActiveCatId] = useState<string | undefined>(undefined);
+  const [activeCatId, setActiveCatId] = useState('');
 
-  // --- Productos (servicios) ---
   const {
     data: products,
     loading: prodsLoading,
     error: prodsError,
     search,
+    pagination,
     refetch: refetchProducts,
-    setFilters,
-  } = useProducts({
-    autoLoad: true,
-    pageSize: 50,
-  });
+  } = useProducts({ autoLoad: true, pageSize: 25 });
+
+  // Búsqueda con debounce
+  const [localSearch, setLocalSearch] = useState('');
+  const debouncedSearch = UI.useDebounce(localSearch, 300);
+  const prevDebouncedRef = useRef(debouncedSearch);
 
   useEffect(() => {
-    if (!rootCategory) return;
-    setFilters({ categoryId: activeCatId });
-  }, [rootCategory, activeCatId, setFilters]);
+    if (prevDebouncedRef.current !== debouncedSearch) {
+      prevDebouncedRef.current = debouncedSearch;
+      search(debouncedSearch);
+    }
+  }, [debouncedSearch, search]);
 
-  const filteredServices = useMemo(() => {
+  // Filtrado client-side
+  const allServices = useMemo(() => {
     if (!rootCategory) return [];
     return products.filter(
       (p: Product) =>
@@ -90,17 +133,21 @@ export function ServicesView() {
     );
   }, [products, rootCategory, serviceCategoryIds]);
 
-  // Conteo por categoría (para mostrar en tabs)
   const countByCat = useMemo(() => {
     const map = new Map<string, number>();
-    for (const svc of filteredServices) {
+    for (const svc of allServices) {
       const k = svc.category_id ?? '';
       map.set(k, (map.get(k) ?? 0) + 1);
     }
     return map;
-  }, [filteredServices]);
+  }, [allServices]);
 
-  // --- Sorting local ---
+  const filteredServices = useMemo(() => {
+    if (!activeCatId) return allServices;
+    return allServices.filter((p: Product) => p.category_id === activeCatId);
+  }, [allServices, activeCatId]);
+
+  // Sorting
   const [sortField, setSortField] = useState<SortField | null>(null);
   const [sortDir, setSortDir] = useState<SortDir>(false);
 
@@ -124,110 +171,92 @@ export function ServicesView() {
     const sorted = [...filteredServices];
     sorted.sort((a: Product, b: Product) => {
       let cmp = 0;
-      if (sortField === 'name') {
-        cmp = a.name.localeCompare(b.name);
-      } else if (sortField === 'price') {
-        cmp = (parseFloat(a.sale_price ?? '0') || 0) - (parseFloat(b.sale_price ?? '0') || 0);
-      }
+      if (sortField === 'name') cmp = a.name.localeCompare(b.name);
+      else cmp = (parseFloat(a.sale_price ?? '0') || 0) - (parseFloat(b.sale_price ?? '0') || 0);
       return sortDir === 'desc' ? -cmp : cmp;
     });
     return sorted;
   }, [filteredServices, sortField, sortDir]);
 
-  // --- Mutaciones ---
+  // Mutaciones
   const { create, update, remove, creating, updating } = useProductMutations();
 
-  // --- Modal ---
+  // Modal state
   const [showModal, setShowModal] = useState(false);
   const [editingService, setEditingService] = useState<Product | null>(null);
-  const [form, setForm] = useState<ServiceFormData>(EMPTY_FORM);
-
-  const [localSearch, setLocalSearch] = useState('');
-
-  // --- Confirmación inline para eliminar ---
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
 
-  // --- Búsqueda ---
-  const handleSearchChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const val = e.target.value;
-      setLocalSearch(val);
-      search(val);
-    },
-    [search]
-  );
+  const categoryMap = useMemo(() => createCategoryMap(categories), [categories]);
 
-  // --- Filtro por categoría via tabs ---
-  const handleTabChange = useCallback((val: string) => {
-    setActiveCatId(val === 'all' ? undefined : val);
-  }, []);
+  const loading = catsLoading || prodsLoading;
+  const isSaving = creating || updating;
+  const hasFilters = !!localSearch || !!activeCatId;
 
-  // --- Abrir modal para crear ---
+  const totalPages = Math.max(1, Math.ceil(pagination.total / pagination.pageSize));
+
+  // Handlers
+  const handleClearFilters = useCallback(() => {
+    setLocalSearch('');
+    search('');
+    setActiveCatId('');
+  }, [search]);
+
   const handleCreate = useCallback(() => {
     setEditingService(null);
-    setForm({
-      ...EMPTY_FORM,
-      categoryId: serviceCategories.length > 0 ? serviceCategories[0].id : '',
-    });
-    setShowModal(true);
-  }, [serviceCategories]);
-
-  // --- Abrir modal para editar ---
-  const handleEdit = useCallback((service: Product) => {
-    setEditingService(service);
-    setForm({
-      name: service.name,
-      description: service.description ?? '',
-      categoryId: service.category_id ?? '',
-      price: service.sale_price ?? '0',
-    });
     setShowModal(true);
   }, []);
 
-  // --- Cerrar modal ---
+  const handleEdit = useCallback((service: Product) => {
+    setEditingService(service);
+    setShowModal(true);
+  }, []);
+
   const handleCloseModal = useCallback(() => {
     setShowModal(false);
     setEditingService(null);
-    setForm(EMPTY_FORM);
   }, []);
 
-  // --- Submit ---
-  const handleSubmit = useCallback(async () => {
-    if (!form.name.trim()) {
-      toast.error('Error', 'El nombre del servicio es obligatorio');
-      return;
-    }
-
-    if (editingService) {
-      const result = await update(editingService.id, {
-        name: form.name.trim(),
-        description: form.description.trim() || null,
-        category_id: form.categoryId || null,
-        sale_price: form.price || '0',
-      });
-      if (result) {
-        handleCloseModal();
-        await refetchProducts();
+  const handleSave = useCallback(
+    async (values: ServiceFormValues): Promise<boolean> => {
+      try {
+        if (editingService) {
+          const result = await update(editingService.id, {
+            name: values.name.trim(),
+            description: values.description.trim() || null,
+            category_id: values.categoryId || null,
+            sale_price: values.price || '0',
+          });
+          if (result) {
+            await refetchProducts();
+            return true;
+          }
+        } else {
+          const data: ProductCreateData = {
+            name: values.name.trim(),
+            description: values.description.trim() || null,
+            category_id: values.categoryId || null,
+            sale_price: values.price || '0',
+            stock_current: '0',
+            stock_minimum: '0',
+            metadata: { type: 'service' },
+          };
+          const result = await create(data);
+          if (result) {
+            await refetchProducts();
+            return true;
+          }
+        }
+      } catch {
+        toast.error(
+          'Error',
+          'No se pudo guardar el servicio. Verificá tu conexión e intentá de nuevo.'
+        );
       }
-    } else {
-      const data: ProductCreateData = {
-        name: form.name.trim(),
-        description: form.description.trim() || null,
-        category_id: form.categoryId || null,
-        sale_price: form.price || '0',
-        stock_current: '0',
-        stock_minimum: '0',
-        metadata: { type: 'service' },
-      };
-      const result = await create(data);
-      if (result) {
-        handleCloseModal();
-        await refetchProducts();
-      }
-    }
-  }, [form, editingService, create, update, toast, handleCloseModal, refetchProducts]);
+      return false;
+    },
+    [editingService, create, update, toast, refetchProducts]
+  );
 
-  // --- Eliminar ---
   const handleDelete = useCallback(
     async (serviceId: string) => {
       const ok = await remove(serviceId);
@@ -239,20 +268,17 @@ export function ServicesView() {
     [remove, refetchProducts]
   );
 
-  const categoryMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const c of categories) map.set(c.id, c.name);
-    return map;
-  }, [categories]);
+  // Valores iniciales para el dialog de edición
+  const editInitialValues = useMemo(() => {
+    if (!editingService) return null;
+    return {
+      name: editingService.name,
+      description: editingService.description ?? '',
+      categoryId: editingService.category_id ?? '',
+      price: editingService.sale_price ?? '0',
+    };
+  }, [editingService]);
 
-  const loading = catsLoading || prodsLoading;
-  const isSaving = creating || updating;
-
-  let submitLabel = 'Crear servicio';
-  if (isSaving) submitLabel = 'Guardando...';
-  else if (editingService) submitLabel = 'Guardar cambios';
-
-  // --- Contenido de la tabla ---
   function renderTableContent(): ReturnType<typeof React.createElement> {
     if (loading) {
       return React.createElement(UI.LoadingOverlay, {
@@ -284,7 +310,7 @@ export function ServicesView() {
       });
     }
     if (services.length === 0) {
-      if (localSearch || activeCatId) {
+      if (hasFilters) {
         return React.createElement(UI.EmptyState, {
           title: 'Sin resultados',
           description: 'No se encontraron servicios con esos filtros.',
@@ -295,15 +321,7 @@ export function ServicesView() {
           }),
           action: React.createElement(
             UI.Button,
-            {
-              variant: 'outline',
-              size: 'sm',
-              onClick: () => {
-                setLocalSearch('');
-                search('');
-                setActiveCatId(undefined);
-              },
-            },
+            { variant: 'outline', size: 'sm', onClick: handleClearFilters },
             'Limpiar filtros'
           ),
           className: 'py-12',
@@ -319,8 +337,8 @@ export function ServicesView() {
         }),
         action: React.createElement(
           UI.Button,
-          { size: 'sm', onClick: handleCreate },
-          React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 14 }),
+          { variant: 'brand', onClick: handleCreate, className: 'gap-2' },
+          React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 20 }),
           'Nuevo servicio'
         ),
         className: 'py-12',
@@ -328,346 +346,300 @@ export function ServicesView() {
     }
 
     return React.createElement(
-      UI.Table,
+      React.Fragment,
       null,
       React.createElement(
-        UI.TableHeader,
-        null,
+        UI.Table,
+        { className: 'table-fixed w-full' },
         React.createElement(
-          UI.TableRow,
+          UI.TableHeader,
           null,
           React.createElement(
-            UI.TableHead,
-            {
-              sortDirection: sortField === 'name' ? sortDir : undefined,
-              onSort: () => handleSort('name'),
-            },
-            'Servicio'
-          ),
-          React.createElement(UI.TableHead, null, 'Categoría'),
-          React.createElement(
-            UI.TableHead,
-            {
-              className: 'text-right',
-              sortDirection: sortField === 'price' ? sortDir : undefined,
-              onSort: () => handleSort('price'),
-            },
-            'Precio'
-          ),
-          React.createElement(UI.TableHead, { className: 'w-24' }, '')
-        )
-      ),
-      React.createElement(
-        UI.TableBody,
-        null,
-        services.map((svc: Product) => {
-          const priceFormatted = formatPrice(svc.sale_price);
-          const catName = categoryMap.get(svc.category_id ?? '');
-
-          return React.createElement(
             UI.TableRow,
-            { key: svc.id, className: 'group' },
-
-            // Nombre + descripción
-            React.createElement(
-              UI.TableCell,
-              null,
-              React.createElement('span', { className: 'font-semibold text-cg-text' }, svc.name),
-              svc.description &&
-                React.createElement(
-                  'p',
-                  { className: 'text-xs text-cg-text-muted mt-0.5 line-clamp-1' },
-                  svc.description
-                )
-            ),
-
-            // Categoría como badge
-            React.createElement(
-              UI.TableCell,
-              null,
-              catName
-                ? React.createElement(UI.Badge, { variant: 'secondary', size: 'sm' }, catName)
-                : React.createElement('span', { className: 'text-cg-text-muted text-sm' }, '—')
-            ),
-
-            // Precio
-            React.createElement(
-              UI.TableCell,
-              { className: 'text-right' },
-              priceFormatted
-                ? React.createElement(
-                    UI.Badge,
-                    { variant: 'brand-soft', size: 'sm' },
-                    priceFormatted
-                  )
-                : React.createElement('span', { className: 'text-sm text-cg-text-muted' }, '—')
-            ),
-
-            // Acciones
-            React.createElement(
-              UI.TableCell,
-              { className: 'text-right' },
-              confirmingDeleteId === svc.id
-                ? React.createElement(UI.InlineConfirm, {
-                    message: '¿Eliminar servicio?',
-                    onConfirm: () => {
-                      void handleDelete(svc.id);
-                    },
-                    onCancel: () => setConfirmingDeleteId(null),
-                  })
-                : React.createElement(
-                    'div',
-                    {
-                      className:
-                        'flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity',
-                    },
-                    React.createElement(UI.Tooltip, {
-                      content: 'Editar',
-                      children: React.createElement(
-                        UI.IconButton,
-                        {
-                          variant: 'ghost',
-                          size: 'xs',
-                          onClick: () => handleEdit(svc),
-                        },
-                        React.createElement(UI.DynamicIcon, { icon: 'SquarePen', size: 16 })
-                      ),
-                    }),
-                    React.createElement(UI.Tooltip, {
-                      content: 'Eliminar',
-                      children: React.createElement(
-                        UI.IconButton,
-                        {
-                          variant: 'danger',
-                          size: 'xs',
-                          onClick: () => setConfirmingDeleteId(svc.id),
-                        },
-                        React.createElement(UI.DynamicIcon, { icon: 'Trash2', size: 16 })
-                      ),
-                    })
-                  )
-            )
-          );
-        })
-      )
-    );
-  }
-
-  return React.createElement(
-    UI.TooltipProvider,
-    null,
-    React.createElement(
-      'div',
-      { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
-      React.createElement(
-        'div',
-        { className: 'w-full flex flex-col gap-6' },
-
-        // === Header: título a la izquierda, acción a la derecha ===
-        React.createElement(
-          'div',
-          { className: 'flex items-start justify-between gap-4' },
-          React.createElement(
-            'div',
             null,
             React.createElement(
-              'h1',
-              { className: 'text-2xl font-bold text-cg-text' },
-              'Servicios y Precios'
+              UI.TableHead,
+              {
+                className: 'w-auto',
+                sortDirection: sortField === 'name' ? sortDir : undefined,
+                onSort: () => handleSort('name'),
+              },
+              'Servicio'
             ),
             React.createElement(
-              'div',
-              { className: 'flex items-center gap-2 mt-1' },
-              React.createElement(
-                'p',
-                { className: 'text-sm text-cg-text-muted' },
-                'Catálogo de servicios veterinarios'
-              ),
-              !loading &&
-                services.length > 0 &&
-                React.createElement(
-                  UI.Badge,
-                  { variant: 'secondary', size: 'sm' },
-                  `${filteredServices.length} servicio${filteredServices.length === 1 ? '' : 's'}`
-                )
-            )
-          ),
-          React.createElement(
-            UI.Button,
-            { onClick: handleCreate },
-            React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 16 }),
-            'Nuevo servicio'
+              UI.TableHead,
+              { className: 'w-36 hidden sm:table-cell' },
+              'Categoría'
+            ),
+            React.createElement(
+              UI.TableHead,
+              {
+                className: 'w-28 text-right',
+                sortDirection: sortField === 'price' ? sortDir : undefined,
+                onSort: () => handleSort('price'),
+              },
+              'Precio'
+            ),
+            React.createElement(UI.TableHead, { className: 'w-20' }, '')
           )
         ),
-
-        // === Búsqueda + categorías ===
         React.createElement(
-          'div',
-          { className: 'flex flex-col gap-3' },
+          UI.TableBody,
+          null,
+          services.map((svc: Product) => {
+            const priceText = formatPrice(svc.sale_price);
+            const catName = categoryMap.get(svc.category_id ?? '');
 
-          // Búsqueda con ícono
-          React.createElement(
-            'div',
-            { className: 'relative' },
-            React.createElement(UI.DynamicIcon, {
-              icon: 'Search',
-              size: 16,
-              className: 'absolute left-3 top-1/2 -translate-y-1/2 text-cg-text-muted',
-            }),
-            React.createElement(UI.Input, {
-              type: 'text',
-              placeholder: 'Buscar servicio...',
-              value: localSearch,
-              onChange: handleSearchChange,
-              className: 'pl-10',
-            })
-          ),
+            return React.createElement(
+              UI.TableRow,
+              { key: svc.id, className: 'group' },
 
-          // Tabs de categorías con conteo
-          serviceCategories.length > 0 &&
-            React.createElement(
-              UI.Tabs,
-              { value: activeCatId ?? 'all', onValueChange: handleTabChange },
               React.createElement(
-                UI.TabsList,
-                { className: 'bg-transparent p-0' },
+                UI.TableCell,
+                { className: 'max-w-xs' },
                 React.createElement(
-                  UI.TabsTrigger,
-                  { value: 'all' },
-                  !loading ? `Todos (${filteredServices.length})` : 'Todos'
+                  'span',
+                  { className: 'font-semibold text-cg-text block truncate' },
+                  svc.name
                 ),
-                ...serviceCategories.map((cat: Category) => {
-                  const count = countByCat.get(cat.id) ?? 0;
-                  return React.createElement(
-                    UI.TabsTrigger,
-                    { key: cat.id, value: cat.id },
-                    !loading ? `${cat.name} (${count})` : cat.name
-                  );
-                })
-              )
-            )
-        ),
+                svc.description &&
+                  React.createElement(
+                    'p',
+                    {
+                      className: 'text-xs text-cg-text-muted mt-0.5 line-clamp-1',
+                      title: svc.description,
+                    },
+                    svc.description
+                  ),
+                // Categoría inline en mobile
+                catName &&
+                  React.createElement(
+                    'span',
+                    { className: 'sm:hidden mt-1 inline-block' },
+                    React.createElement(UI.Badge, { variant: 'secondary', size: 'sm' }, catName)
+                  )
+              ),
 
-        // === Tabla ===
-        React.createElement(UI.Card, { className: 'overflow-hidden' }, renderTableContent())
-      ),
-
-      // === Modal crear/editar ===
-      showModal &&
-        React.createElement(UI.FormDialog, {
-          open: showModal,
-          onOpenChange: (open: boolean) => {
-            if (!open) handleCloseModal();
-          },
-          title: editingService ? 'Editar servicio' : 'Nuevo servicio',
-          size: 'sm',
-          footer: React.createElement(
-            React.Fragment,
-            null,
-            React.createElement(
-              UI.Button,
-              { type: 'button', variant: 'outline', onClick: handleCloseModal },
-              'Cancelar'
-            ),
-            React.createElement(
-              UI.Button,
-              {
-                type: 'button',
-                onClick: () => {
-                  void handleSubmit();
-                },
-                disabled: isSaving,
-              },
-              submitLabel
-            )
-          ),
-          children: React.createElement(
-            React.Fragment,
-            null,
-
-            // Nombre
-            React.createElement(
-              'div',
-              { className: 'flex flex-col gap-1' },
-              React.createElement(UI.Label, null, 'Nombre *'),
-              React.createElement(UI.Input, {
-                type: 'text',
-                value: form.name,
-                onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                  setForm((prev: ServiceFormData) => ({ ...prev, name: e.target.value })),
-                placeholder: 'Ej: Consulta general',
-              })
-            ),
-
-            // Descripción
-            React.createElement(
-              'div',
-              { className: 'flex flex-col gap-1' },
-              React.createElement(UI.Label, null, 'Descripción (opcional)'),
-              React.createElement(UI.Textarea, {
-                value: form.description,
-                onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                  setForm((prev: ServiceFormData) => ({
-                    ...prev,
-                    description: e.target.value,
-                  })),
-                rows: 2,
-                placeholder: 'Descripción opcional del servicio',
-              })
-            ),
-
-            // Categoría
-            React.createElement(
-              'div',
-              { className: 'flex flex-col gap-1' },
-              React.createElement(UI.Label, null, 'Categoría'),
               React.createElement(
-                UI.Select,
-                {
-                  value: form.categoryId,
-                  onValueChange: (v: string) =>
-                    setForm((prev: ServiceFormData) => ({
-                      ...prev,
-                      categoryId: v,
-                    })),
-                },
-                serviceCategories.map((cat: Category) =>
-                  React.createElement(UI.SelectItem, { key: cat.id, value: cat.id }, cat.name)
-                )
-              )
-            ),
+                UI.TableCell,
+                { className: 'hidden sm:table-cell' },
+                catName
+                  ? React.createElement(UI.Badge, { variant: 'secondary', size: 'sm' }, catName)
+                  : React.createElement('span', { className: 'text-cg-text-muted text-sm' }, '—')
+              ),
 
-            // Precio
-            React.createElement(
-              'div',
-              { className: 'flex flex-col gap-1' },
-              React.createElement(UI.Label, null, 'Precio'),
               React.createElement(
-                'div',
-                { className: 'relative' },
+                UI.TableCell,
+                { className: 'text-right' },
                 React.createElement(
                   'span',
                   {
                     className:
-                      'absolute left-3 top-1/2 -translate-y-1/2 text-sm text-cg-text-muted',
+                      priceText !== '—'
+                        ? 'text-sm font-medium text-cg-text tabular-nums'
+                        : 'text-sm text-cg-text-muted',
                   },
-                  '$'
-                ),
-                React.createElement(UI.Input, {
-                  type: 'text',
-                  inputMode: 'decimal',
-                  value: form.price,
+                  priceText
+                )
+              ),
+
+              // Acciones — visibles en touch, hover en desktop
+              React.createElement(
+                UI.TableCell,
+                { className: 'text-right' },
+                confirmingDeleteId === svc.id
+                  ? React.createElement(UI.InlineConfirm, {
+                      message: '¿Eliminar?',
+                      onConfirm: () => {
+                        void handleDelete(svc.id);
+                      },
+                      onCancel: () => setConfirmingDeleteId(null),
+                    })
+                  : React.createElement(
+                      'div',
+                      {
+                        className:
+                          'flex items-center justify-end gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100 transition-opacity',
+                      },
+                      React.createElement(UI.Tooltip, {
+                        content: 'Editar',
+                        children: React.createElement(
+                          UI.IconButton,
+                          {
+                            variant: 'ghost',
+                            size: 'xs',
+                            'aria-label': `Editar ${svc.name}`,
+                            onClick: () => handleEdit(svc),
+                          },
+                          React.createElement(UI.DynamicIcon, { icon: 'SquarePen', size: 16 })
+                        ),
+                      }),
+                      React.createElement(UI.Tooltip, {
+                        content: 'Eliminar',
+                        children: React.createElement(
+                          UI.IconButton,
+                          {
+                            variant: 'danger',
+                            size: 'xs',
+                            'aria-label': `Eliminar ${svc.name}`,
+                            onClick: () => setConfirmingDeleteId(svc.id),
+                          },
+                          React.createElement(UI.DynamicIcon, { icon: 'Trash2', size: 16 })
+                        ),
+                      })
+                    )
+              )
+            );
+          })
+        )
+      ),
+
+      totalPages > 1 &&
+        React.createElement(
+          'div',
+          {
+            className:
+              'flex items-center justify-between px-4 py-3 border-t border-cg-border-subtle',
+          },
+          React.createElement(
+            'span',
+            { className: 'text-xs text-cg-text-muted' },
+            `Página ${pagination.page} de ${totalPages}`
+          ),
+          React.createElement(
+            UI.Pagination,
+            null,
+            React.createElement(
+              UI.PaginationContent,
+              null,
+              React.createElement(UI.PaginationPrevious, {
+                onClick: () => pagination.setPage(pagination.page - 1),
+                'aria-disabled': pagination.page <= 1,
+                className: pagination.page <= 1 ? 'pointer-events-none opacity-50' : '',
+              }),
+              ...buildPageLinks(pagination.page, totalPages, pagination.setPage),
+              React.createElement(UI.PaginationNext, {
+                onClick: () => pagination.setPage(pagination.page + 1),
+                'aria-disabled': pagination.page >= totalPages,
+                className: pagination.page >= totalPages ? 'pointer-events-none opacity-50' : '',
+              })
+            )
+          )
+        )
+    );
+  }
+
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement(
+      UI.TooltipProvider,
+      null,
+      React.createElement(
+        'div',
+        { className: 'min-h-screen bg-cg-bg-secondary p-4 sm:p-6' },
+        React.createElement(
+          'div',
+          { className: 'w-full flex flex-col gap-6' },
+
+          React.createElement(UI.PageHeader, {
+            title: 'Servicios',
+            subtitle:
+              !loading && allServices.length > 0
+                ? `${allServices.length} servicio${allServices.length === 1 ? '' : 's'} en catálogo`
+                : 'Catálogo de servicios veterinarios',
+            action: React.createElement(
+              UI.Button,
+              { onClick: handleCreate, variant: 'brand', className: 'gap-2' },
+              React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 20 }),
+              'Nuevo servicio'
+            ),
+          }),
+
+          React.createElement(
+            'div',
+            {
+              'aria-busy': loading,
+              'aria-label': 'Tabla de servicios',
+              role: 'region',
+              className: 'bg-cg-bg rounded-xl border border-cg-border p-6 shadow-sm',
+            },
+            React.createElement(
+              'div',
+              { className: 'flex flex-col gap-4' },
+
+              // Filtros inline: búsqueda izquierda + categorías derecha
+              React.createElement(
+                'div',
+                {
+                  className: 'flex flex-wrap items-end justify-between gap-4',
+                  role: 'search',
+                  'aria-label': 'Filtrar servicios',
+                },
+                React.createElement(UI.SearchInput, {
+                  placeholder: 'Buscar...',
+                  value: localSearch,
                   onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                    setForm((prev: ServiceFormData) => ({ ...prev, price: e.target.value })),
-                  min: '0',
-                  step: '0.01',
-                  placeholder: '0.00',
-                  className: 'pl-7',
-                })
+                    setLocalSearch(e.target.value),
+                  className: 'w-56 shrink-0',
+                  'aria-label': 'Buscar servicios',
+                }),
+                React.createElement(
+                  'div',
+                  { className: 'flex items-end gap-3 flex-wrap' },
+                  serviceCategories.length > 0 &&
+                    React.createElement(
+                      UI.ButtonGroup,
+                      null,
+                      React.createElement(
+                        UI.ButtonGroupItem,
+                        {
+                          key: '__all',
+                          active: !activeCatId,
+                          onClick: () => setActiveCatId(''),
+                        },
+                        loading ? 'Todos' : `Todos (${allServices.length})`
+                      ),
+                      ...serviceCategories.map((cat: Category) =>
+                        React.createElement(
+                          UI.ButtonGroupItem,
+                          {
+                            key: cat.id,
+                            active: activeCatId === cat.id,
+                            onClick: () => setActiveCatId(activeCatId === cat.id ? '' : cat.id),
+                          },
+                          loading ? cat.name : `${cat.name} (${countByCat.get(cat.id) ?? 0})`
+                        )
+                      )
+                    ),
+                  hasFilters &&
+                    React.createElement(
+                      UI.Button,
+                      { variant: 'link', size: 'xs', onClick: handleClearFilters },
+                      'Limpiar filtros'
+                    )
+                )
+              ),
+
+              // Tabla
+              React.createElement(
+                'div',
+                { className: 'overflow-x-auto -mx-6' },
+                React.createElement('div', { className: 'px-6' }, renderTableContent())
               )
             )
-          ),
-        })
-    )
+          )
+        )
+      )
+    ),
+
+    React.createElement(ServiceFormDialog, {
+      open: showModal,
+      onClose: handleCloseModal,
+      onSave: handleSave,
+      initialValues: editInitialValues,
+      categories: serviceCategories,
+      saving: isSaving,
+    })
   );
 }

--- a/src/views/services/index.tsx
+++ b/src/views/services/index.tsx
@@ -90,6 +90,16 @@ export function ServicesView() {
     );
   }, [products, rootCategory, serviceCategoryIds]);
 
+  // Conteo por categoría (para mostrar en tabs)
+  const countByCat = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const svc of filteredServices) {
+      const k = svc.category_id ?? '';
+      map.set(k, (map.get(k) ?? 0) + 1);
+    }
+    return map;
+  }, [filteredServices]);
+
   // --- Sorting local ---
   const [sortField, setSortField] = useState<SortField | null>(null);
   const [sortDir, setSortDir] = useState<SortDir>(false);
@@ -242,7 +252,7 @@ export function ServicesView() {
   if (isSaving) submitLabel = 'Guardando...';
   else if (editingService) submitLabel = 'Guardar cambios';
 
-  // Contenido de la tabla (loading / error / vacío / filas)
+  // --- Contenido de la tabla ---
   function renderTableContent(): ReturnType<typeof React.createElement> {
     if (loading) {
       return React.createElement(UI.LoadingOverlay, {
@@ -274,7 +284,6 @@ export function ServicesView() {
       });
     }
     if (services.length === 0) {
-      // Estado vacío con filtros activos
       if (localSearch || activeCatId) {
         return React.createElement(UI.EmptyState, {
           title: 'Sin resultados',
@@ -300,7 +309,6 @@ export function ServicesView() {
           className: 'py-12',
         });
       }
-      // Estado vacío sin filtros
       return React.createElement(UI.EmptyState, {
         title: 'Sin servicios registrados',
         description: 'Agregá tu primer servicio para comenzar a gestionarlos.',
@@ -354,6 +362,7 @@ export function ServicesView() {
         null,
         services.map((svc: Product) => {
           const priceFormatted = formatPrice(svc.sale_price);
+          const catName = categoryMap.get(svc.category_id ?? '');
 
           return React.createElement(
             UI.TableRow,
@@ -363,20 +372,22 @@ export function ServicesView() {
             React.createElement(
               UI.TableCell,
               null,
-              React.createElement('div', { className: 'font-medium text-cg-text' }, svc.name),
+              React.createElement('span', { className: 'font-semibold text-cg-text' }, svc.name),
               svc.description &&
                 React.createElement(
-                  'div',
+                  'p',
                   { className: 'text-xs text-cg-text-muted mt-0.5 line-clamp-1' },
                   svc.description
                 )
             ),
 
-            // Categoría
+            // Categoría como badge
             React.createElement(
               UI.TableCell,
-              { className: 'text-cg-text-muted' },
-              categoryMap.get(svc.category_id ?? '') ?? '-'
+              null,
+              catName
+                ? React.createElement(UI.Badge, { variant: 'secondary', size: 'sm' }, catName)
+                : React.createElement('span', { className: 'text-cg-text-muted text-sm' }, '—')
             ),
 
             // Precio
@@ -450,90 +461,98 @@ export function ServicesView() {
       { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
       React.createElement(
         'div',
-        { className: 'max-w-6xl mx-auto flex flex-col gap-6' },
+        { className: 'w-full flex flex-col gap-6' },
 
-        // Header de página
+        // === Header: título a la izquierda, acción a la derecha ===
         React.createElement(
           'div',
-          null,
+          { className: 'flex items-start justify-between gap-4' },
           React.createElement(
-            'h1',
-            { className: 'text-2xl font-bold text-cg-text' },
-            'Servicios y Precios'
+            'div',
+            null,
+            React.createElement(
+              'h1',
+              { className: 'text-2xl font-bold text-cg-text' },
+              'Servicios y Precios'
+            ),
+            React.createElement(
+              'div',
+              { className: 'flex items-center gap-2 mt-1' },
+              React.createElement(
+                'p',
+                { className: 'text-sm text-cg-text-muted' },
+                'Catálogo de servicios veterinarios'
+              ),
+              !loading &&
+                services.length > 0 &&
+                React.createElement(
+                  UI.Badge,
+                  { variant: 'secondary', size: 'sm' },
+                  `${filteredServices.length} servicio${filteredServices.length === 1 ? '' : 's'}`
+                )
+            )
           ),
           React.createElement(
-            'p',
-            { className: 'text-sm text-cg-text-muted mt-1' },
-            'Gestionar servicios veterinarios y sus precios'
+            UI.Button,
+            { onClick: handleCreate },
+            React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 16 }),
+            'Nuevo servicio'
           )
         ),
 
-        // Card unificada: toolbar + tabla
+        // === Búsqueda + categorías ===
         React.createElement(
-          UI.Card,
-          { className: 'overflow-hidden' },
+          'div',
+          { className: 'flex flex-col gap-3' },
 
-          // Toolbar: búsqueda + acción
+          // Búsqueda con ícono
           React.createElement(
             'div',
-            { className: 'flex items-center gap-3 p-4' },
+            { className: 'relative' },
+            React.createElement(UI.DynamicIcon, {
+              icon: 'Search',
+              size: 16,
+              className: 'absolute left-3 top-1/2 -translate-y-1/2 text-cg-text-muted',
+            }),
             React.createElement(UI.Input, {
               type: 'text',
               placeholder: 'Buscar servicio...',
               value: localSearch,
               onChange: handleSearchChange,
-              className: 'flex-1',
-            }),
-            React.createElement(
-              UI.Button,
-              { onClick: handleCreate },
-              React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 16 }),
-              'Nuevo servicio'
-            )
+              className: 'pl-10',
+            })
           ),
 
-          // Tabs de categorías
+          // Tabs de categorías con conteo
           serviceCategories.length > 0 &&
             React.createElement(
-              'div',
-              { className: 'px-4 pb-4' },
+              UI.Tabs,
+              { value: activeCatId ?? 'all', onValueChange: handleTabChange },
               React.createElement(
-                UI.Tabs,
-                {
-                  value: activeCatId ?? 'all',
-                  onValueChange: handleTabChange,
-                },
+                UI.TabsList,
+                { className: 'bg-transparent p-0' },
                 React.createElement(
-                  UI.TabsList,
-                  { className: 'bg-transparent p-0' },
-                  React.createElement(UI.TabsTrigger, { value: 'all' }, 'Todos'),
-                  ...serviceCategories.map((cat: Category) =>
-                    React.createElement(UI.TabsTrigger, { key: cat.id, value: cat.id }, cat.name)
-                  )
-                )
+                  UI.TabsTrigger,
+                  { value: 'all' },
+                  !loading ? `Todos (${filteredServices.length})` : 'Todos'
+                ),
+                ...serviceCategories.map((cat: Category) => {
+                  const count = countByCat.get(cat.id) ?? 0;
+                  return React.createElement(
+                    UI.TabsTrigger,
+                    { key: cat.id, value: cat.id },
+                    !loading ? `${cat.name} (${count})` : cat.name
+                  );
+                })
               )
-            ),
+            )
+        ),
 
-          React.createElement(UI.Separator, null),
-
-          // Contador de resultados
-          !loading &&
-            React.createElement(
-              'div',
-              { className: 'flex justify-end px-4 py-2' },
-              React.createElement(
-                'span',
-                { className: 'text-xs text-cg-text-muted' },
-                `${services.length} servicio${services.length === 1 ? '' : 's'}`
-              )
-            ),
-
-          // Contenido de la tabla
-          renderTableContent()
-        )
+        // === Tabla ===
+        React.createElement(UI.Card, { className: 'overflow-hidden' }, renderTableContent())
       ),
 
-      // Modal crear/editar servicio
+      // === Modal crear/editar ===
       showModal &&
         React.createElement(UI.FormDialog, {
           open: showModal,

--- a/src/views/services/index.tsx
+++ b/src/views/services/index.tsx
@@ -33,9 +33,9 @@ type SortField = 'name' | 'price';
 type SortDir = 'asc' | 'desc' | false;
 
 function formatPrice(value: string | null): string {
-  if (!value || value === '0') return '-';
+  if (!value || value === '0') return '';
   const num = parseFloat(value);
-  return isNaN(num) ? '-' : `$${num.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`;
+  return isNaN(num) ? '' : `$${num.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`;
 }
 
 export function ServicesView() {
@@ -44,7 +44,6 @@ export function ServicesView() {
   // --- Categorías ---
   const { categories, loading: catsLoading } = useCategories();
 
-  // Encontrar la categoría raíz de servicios y sus hijas
   const rootCategory = useMemo(
     () => categories.find((c: Category) => c.slug === ROOT_SERVICE_CATEGORY_SLUG) ?? null,
     [categories]
@@ -78,13 +77,11 @@ export function ServicesView() {
     pageSize: 50,
   });
 
-  // Refiltrar por subcategoría cuando cambia el chip activo o la categoría raíz carga
   useEffect(() => {
     if (!rootCategory) return;
     setFilters({ categoryId: activeCatId });
   }, [rootCategory, activeCatId, setFilters]);
 
-  // Filtrar solo servicios de las subcategorías conocidas (o la raíz)
   const filteredServices = useMemo(() => {
     if (!rootCategory) return [];
     return products.filter(
@@ -150,9 +147,9 @@ export function ServicesView() {
     [search]
   );
 
-  // --- Filtro por categoría ---
-  const handleCategoryFilter = useCallback((catId: string) => {
-    setActiveCatId((prev: string | undefined) => (prev === catId ? undefined : catId));
+  // --- Filtro por categoría via tabs ---
+  const handleTabChange = useCallback((val: string) => {
+    setActiveCatId(val === 'all' ? undefined : val);
   }, []);
 
   // --- Abrir modal para crear ---
@@ -245,7 +242,7 @@ export function ServicesView() {
   if (isSaving) submitLabel = 'Guardando...';
   else if (editingService) submitLabel = 'Guardar cambios';
 
-  // Contenido de la card de resultados (loading / error / vacío / tabla)
+  // Contenido de la tabla (loading / error / vacío / filas)
   function renderTableContent(): ReturnType<typeof React.createElement> {
     if (loading) {
       return React.createElement(UI.LoadingOverlay, {
@@ -268,15 +265,56 @@ export function ServicesView() {
       return React.createElement(UI.EmptyState, {
         title: 'Sin categorías de servicios',
         description: 'Reinicie la aplicación para ejecutar el auto-seed.',
+        icon: React.createElement(UI.DynamicIcon, {
+          icon: 'FolderX',
+          size: 24,
+          className: 'text-cg-text-muted',
+        }),
         className: 'py-12',
       });
     }
     if (services.length === 0) {
+      // Estado vacío con filtros activos
+      if (localSearch || activeCatId) {
+        return React.createElement(UI.EmptyState, {
+          title: 'Sin resultados',
+          description: 'No se encontraron servicios con esos filtros.',
+          icon: React.createElement(UI.DynamicIcon, {
+            icon: 'SearchX',
+            size: 24,
+            className: 'text-cg-text-muted',
+          }),
+          action: React.createElement(
+            UI.Button,
+            {
+              variant: 'outline',
+              size: 'sm',
+              onClick: () => {
+                setLocalSearch('');
+                search('');
+                setActiveCatId(undefined);
+              },
+            },
+            'Limpiar filtros'
+          ),
+          className: 'py-12',
+        });
+      }
+      // Estado vacío sin filtros
       return React.createElement(UI.EmptyState, {
-        title:
-          localSearch || activeCatId
-            ? 'No se encontraron servicios con esos filtros'
-            : 'Sin servicios registrados',
+        title: 'Sin servicios registrados',
+        description: 'Agregá tu primer servicio para comenzar a gestionarlos.',
+        icon: React.createElement(UI.DynamicIcon, {
+          icon: 'Stethoscope',
+          size: 24,
+          className: 'text-cg-text-muted',
+        }),
+        action: React.createElement(
+          UI.Button,
+          { size: 'sm', onClick: handleCreate },
+          React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 14 }),
+          'Nuevo servicio'
+        ),
         className: 'py-12',
       });
     }
@@ -314,26 +352,22 @@ export function ServicesView() {
       React.createElement(
         UI.TableBody,
         null,
-        services.map((svc: Product) =>
-          React.createElement(
+        services.map((svc: Product) => {
+          const priceFormatted = formatPrice(svc.sale_price);
+
+          return React.createElement(
             UI.TableRow,
-            { key: svc.id },
+            { key: svc.id, className: 'group' },
 
             // Nombre + descripción
             React.createElement(
               UI.TableCell,
               null,
-              React.createElement(
-                'div',
-                { className: 'font-medium text-[var(--cg-text)]' },
-                svc.name
-              ),
+              React.createElement('div', { className: 'font-medium text-cg-text' }, svc.name),
               svc.description &&
                 React.createElement(
                   'div',
-                  {
-                    className: 'text-xs text-[var(--cg-text-muted)] mt-0.5 line-clamp-1',
-                  },
+                  { className: 'text-xs text-cg-text-muted mt-0.5 line-clamp-1' },
                   svc.description
                 )
             ),
@@ -341,15 +375,21 @@ export function ServicesView() {
             // Categoría
             React.createElement(
               UI.TableCell,
-              { className: 'text-[var(--cg-text-muted)]' },
+              { className: 'text-cg-text-muted' },
               categoryMap.get(svc.category_id ?? '') ?? '-'
             ),
 
             // Precio
             React.createElement(
               UI.TableCell,
-              { className: 'text-right font-medium' },
-              formatPrice(svc.sale_price)
+              { className: 'text-right' },
+              priceFormatted
+                ? React.createElement(
+                    UI.Badge,
+                    { variant: 'brand-soft', size: 'sm' },
+                    priceFormatted
+                  )
+                : React.createElement('span', { className: 'text-sm text-cg-text-muted' }, '—')
             ),
 
             // Acciones
@@ -366,7 +406,10 @@ export function ServicesView() {
                   })
                 : React.createElement(
                     'div',
-                    { className: 'flex items-center justify-end gap-1' },
+                    {
+                      className:
+                        'flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity',
+                    },
                     React.createElement(UI.Tooltip, {
                       content: 'Editar',
                       children: React.createElement(
@@ -393,8 +436,8 @@ export function ServicesView() {
                     })
                   )
             )
-          )
-        )
+          );
+        })
       )
     );
   }
@@ -404,85 +447,90 @@ export function ServicesView() {
     null,
     React.createElement(
       'div',
-      { className: 'font-inter min-h-screen bg-[var(--cg-bg-secondary)] p-6' },
+      { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
       React.createElement(
         'div',
-        { className: 'max-w-4xl mx-auto flex flex-col gap-6' },
+        { className: 'max-w-6xl mx-auto flex flex-col gap-6' },
 
-        // Header
+        // Header de página
         React.createElement(
           'div',
-          { className: 'flex items-center justify-between' },
+          null,
           React.createElement(
-            'div',
-            null,
-            React.createElement(
-              'h1',
-              { className: 'text-2xl font-bold text-[var(--cg-text)]' },
-              'Servicios y Precios'
-            ),
-            React.createElement(
-              'p',
-              { className: 'text-sm text-[var(--cg-text-muted)] mt-1' },
-              'Gestionar servicios veterinarios y sus precios'
-            )
+            'h1',
+            { className: 'text-2xl font-bold text-cg-text' },
+            'Servicios y Precios'
           ),
           React.createElement(
-            UI.Button,
-            { onClick: handleCreate },
-            React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 16 }),
-            'Nuevo servicio'
+            'p',
+            { className: 'text-sm text-cg-text-muted mt-1' },
+            'Gestionar servicios veterinarios y sus precios'
           )
         ),
 
-        // Filtros
+        // Card unificada: toolbar + tabla
         React.createElement(
           UI.Card,
-          { className: 'p-4' },
+          { className: 'overflow-hidden' },
+
+          // Toolbar: búsqueda + acción
           React.createElement(
             'div',
-            { className: 'flex flex-col gap-3' },
-
-            // Barra de búsqueda
+            { className: 'flex items-center gap-3 p-4' },
             React.createElement(UI.Input, {
               type: 'text',
               placeholder: 'Buscar servicio...',
               value: localSearch,
               onChange: handleSearchChange,
+              className: 'flex-1',
             }),
+            React.createElement(
+              UI.Button,
+              { onClick: handleCreate },
+              React.createElement(UI.DynamicIcon, { icon: 'Plus', size: 16 }),
+              'Nuevo servicio'
+            )
+          ),
 
-            // Chips de categorías
-            serviceCategories.length > 0 &&
+          // Tabs de categorías
+          serviceCategories.length > 0 &&
+            React.createElement(
+              'div',
+              { className: 'px-4 pb-4' },
               React.createElement(
-                'div',
-                { className: 'flex flex-wrap gap-2' },
-                serviceCategories.map((cat: Category) =>
-                  React.createElement(
-                    UI.Chip,
-                    {
-                      key: cat.id,
-                      variant: activeCatId === cat.id ? 'brand' : 'default',
-                      onClick: () => handleCategoryFilter(cat.id),
-                      className: 'cursor-pointer',
-                    },
-                    cat.name
+                UI.Tabs,
+                {
+                  value: activeCatId ?? 'all',
+                  onValueChange: handleTabChange,
+                },
+                React.createElement(
+                  UI.TabsList,
+                  { className: 'bg-transparent p-0' },
+                  React.createElement(UI.TabsTrigger, { value: 'all' }, 'Todos'),
+                  ...serviceCategories.map((cat: Category) =>
+                    React.createElement(UI.TabsTrigger, { key: cat.id, value: cat.id }, cat.name)
                   )
                 )
               )
-          )
-        ),
+            ),
 
-        // Resultados
-        React.createElement(UI.Card, { className: 'overflow-hidden' }, renderTableContent()),
+          React.createElement(UI.Separator, null),
 
-        // Contador
-        !loading &&
-          services.length > 0 &&
-          React.createElement(
-            'span',
-            { className: 'text-xs text-[var(--cg-text-muted)]' },
-            `${services.length} servicio${services.length === 1 ? '' : 's'}`
-          )
+          // Contador de resultados
+          !loading &&
+            React.createElement(
+              'div',
+              { className: 'flex justify-end px-4 py-2' },
+              React.createElement(
+                'span',
+                { className: 'text-xs text-cg-text-muted' },
+                `${services.length} servicio${services.length === 1 ? '' : 's'}`
+              )
+            ),
+
+          // Contenido de la tabla
+          renderTableContent()
+        )
       ),
 
       // Modal crear/editar servicio
@@ -536,7 +584,7 @@ export function ServicesView() {
             React.createElement(
               'div',
               { className: 'flex flex-col gap-1' },
-              React.createElement(UI.Label, null, 'Descripción'),
+              React.createElement(UI.Label, null, 'Descripción (opcional)'),
               React.createElement(UI.Textarea, {
                 value: form.description,
                 onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
@@ -582,12 +630,13 @@ export function ServicesView() {
                   'span',
                   {
                     className:
-                      'absolute left-3 top-1/2 -translate-y-1/2 text-sm text-[var(--cg-text-muted)]',
+                      'absolute left-3 top-1/2 -translate-y-1/2 text-sm text-cg-text-muted',
                   },
                   '$'
                 ),
                 React.createElement(UI.Input, {
-                  type: 'number',
+                  type: 'text',
+                  inputMode: 'decimal',
                   value: form.price,
                   onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
                     setForm((prev: ServiceFormData) => ({ ...prev, price: e.target.value })),

--- a/src/views/services/index.tsx
+++ b/src/views/services/index.tsx
@@ -108,6 +108,7 @@ export function ServicesView() {
     loading: prodsLoading,
     error: prodsError,
     search,
+    setFilters: setProductFilters,
     pagination,
     refetch: refetchProducts,
   } = useProducts({ autoLoad: true, pageSize: 25 });
@@ -133,19 +134,14 @@ export function ServicesView() {
     );
   }, [products, rootCategory, serviceCategoryIds]);
 
-  const countByCat = useMemo(() => {
-    const map = new Map<string, number>();
-    for (const svc of allServices) {
-      const k = svc.category_id ?? '';
-      map.set(k, (map.get(k) ?? 0) + 1);
-    }
-    return map;
-  }, [allServices]);
-
-  const filteredServices = useMemo(() => {
-    if (!activeCatId) return allServices;
-    return allServices.filter((p: Product) => p.category_id === activeCatId);
-  }, [allServices, activeCatId]);
+  // Filtro de categoría server-side via setFilters
+  const handleCategoryChange = useCallback(
+    (catId: string) => {
+      setActiveCatId(catId);
+      setProductFilters({ categoryId: catId || undefined });
+    },
+    [setProductFilters]
+  );
 
   // Sorting
   const [sortField, setSortField] = useState<SortField | null>(null);
@@ -167,8 +163,8 @@ export function ServicesView() {
   );
 
   const services = useMemo(() => {
-    if (!sortField || !sortDir) return filteredServices;
-    const sorted = [...filteredServices];
+    if (!sortField || !sortDir) return allServices;
+    const sorted = [...allServices];
     sorted.sort((a: Product, b: Product) => {
       let cmp = 0;
       if (sortField === 'name') cmp = a.name.localeCompare(b.name);
@@ -176,7 +172,7 @@ export function ServicesView() {
       return sortDir === 'desc' ? -cmp : cmp;
     });
     return sorted;
-  }, [filteredServices, sortField, sortDir]);
+  }, [allServices, sortField, sortDir]);
 
   // Mutaciones
   const { create, update, remove, creating, updating } = useProductMutations();
@@ -198,8 +194,8 @@ export function ServicesView() {
   const handleClearFilters = useCallback(() => {
     setLocalSearch('');
     search('');
-    setActiveCatId('');
-  }, [search]);
+    handleCategoryChange('');
+  }, [search, handleCategoryChange]);
 
   const handleCreate = useCallback(() => {
     setEditingService(null);
@@ -591,8 +587,8 @@ export function ServicesView() {
           React.createElement(UI.PageHeader, {
             title: 'Servicios',
             subtitle:
-              !loading && allServices.length > 0
-                ? `${allServices.length} servicio${allServices.length === 1 ? '' : 's'} en catálogo`
+              !loading && pagination.total > 0
+                ? `${pagination.total} servicio${pagination.total === 1 ? '' : 's'} en catálogo`
                 : 'Catálogo de servicios veterinarios',
             action: React.createElement(
               UI.Button,
@@ -642,9 +638,9 @@ export function ServicesView() {
                         {
                           key: '__all',
                           active: !activeCatId,
-                          onClick: () => setActiveCatId(''),
+                          onClick: () => handleCategoryChange(''),
                         },
-                        loading ? 'Todos' : `Todos (${allServices.length})`
+                        'Todos'
                       ),
                       ...serviceCategories.map((cat: Category) =>
                         React.createElement(
@@ -652,9 +648,10 @@ export function ServicesView() {
                           {
                             key: cat.id,
                             active: activeCatId === cat.id,
-                            onClick: () => setActiveCatId(activeCatId === cat.id ? '' : cat.id),
+                            onClick: () =>
+                              handleCategoryChange(activeCatId === cat.id ? '' : cat.id),
                           },
-                          loading ? cat.name : `${cat.name} (${countByCat.get(cat.id) ?? 0})`
+                          cat.name
                         )
                       )
                     ),


### PR DESCRIPTION
Closes #20

## Changes
- Reemplazar toda la notación bracket `[var(--cg-*)]` por tokens directos `cg-*` en todos los componentes
- Extraer utilidades compartidas de precio (`formatCurrency`, `formatPrice`, `sanitizePrice`) y categorías (`createCategoryMap`) a `utils/`
- Crear componentes reutilizables `PriceInput` y `ServiceFormDialog` desde código inline
- Mover data fetching (pet, service totals, catálogo) de componentes presentacionales a vistas padre para mayor reusabilidad
- Rediseñar vista de consultas: columnas consolidadas (motivo+diagnóstico), `PageHeader`, `SearchInput`, empty states mejorados
- Rediseñar vista de servicios: paginación, skeleton de tabla, filtros por categoría con contadores
- Simplificar `ConsultationStats` con `StatCard` compact y `DynamicIcon`
- Agregar NaN guard en cálculo de `servicesTotal`
- Eliminar código muerto (`showPetName`, `onNavigate`, onClick vacío)
- Traducir todos los comentarios en inglés a español según convenciones del proyecto
- Agregar exports públicos faltantes para nuevos componentes y utilidades

## Testing
- [ ] Verificar que la vista de consultas muestra correctamente la tabla con columnas consolidadas
- [ ] Verificar que la vista de servicios carga con skeleton de tabla y pagina correctamente
- [ ] Verificar que crear/editar servicio funciona desde el dialog reutilizable
- [ ] Verificar que los precios se formatean correctamente en todos los contextos
- [ ] Verificar dark mode — todos los tokens `cg-*` deben adaptarse automáticamente
- [ ] Verificar empty states en ambas vistas (con y sin filtros)

🤖 Generated with [Claude Code](https://claude.com/claude-code)