### PR TITLE
fix: normalize layout consistency between views

### DIFF
--- a/src/views/consultations-list/index.tsx
+++ b/src/views/consultations-list/index.tsx
@@ -374,12 +374,12 @@ export function ConsultationsListView() {
           // Filtros: búsqueda + categorías + fechas
           React.createElement(
             'div',
-            { className: 'flex flex-wrap items-end justify-between gap-4' },
+            { className: 'flex flex-wrap items-center justify-between gap-4' },
 
             // Izquierda: búsqueda + categorías
             React.createElement(
               'div',
-              { className: 'flex items-end gap-3 min-w-0 flex-1' },
+              { className: 'flex items-center gap-3 min-w-0 flex-1' },
 
               React.createElement(UI.SearchInput, {
                 placeholder: 'Buscar...',
@@ -426,7 +426,8 @@ export function ConsultationsListView() {
             React.createElement(
               'div',
               {
-                className: 'flex items-end gap-2 shrink-0 bg-cg-bg-secondary rounded-lg px-3 py-2',
+                className:
+                  'flex items-center gap-2 shrink-0 bg-cg-bg-secondary rounded-lg px-3 py-2',
               },
               React.createElement(
                 'div',

--- a/src/views/services/index.tsx
+++ b/src/views/services/index.tsx
@@ -579,7 +579,7 @@ export function ServicesView() {
       null,
       React.createElement(
         'div',
-        { className: 'min-h-screen bg-cg-bg-secondary p-4 sm:p-6' },
+        { className: 'font-inter min-h-screen bg-cg-bg-secondary p-6' },
         React.createElement(
           'div',
           { className: 'w-full flex flex-col gap-6' },
@@ -665,11 +665,7 @@ export function ServicesView() {
               ),
 
               // Tabla
-              React.createElement(
-                'div',
-                { className: 'overflow-x-auto -mx-6' },
-                React.createElement('div', { className: 'px-6' }, renderTableContent())
-              )
+              renderTableContent()
             )
           )
         )


### PR DESCRIPTION
Closes #24

## Changes
- Replace `items-end` with `items-center` in Historial filter containers — `items-end` was unavailable in loaded CSS, causing SearchInput to stretch vertically and misalign with filter buttons/date selector
- Normalize Servicios view outer padding (`p-4 sm:p-6` → `p-6`) and add `font-inter` to match Historial layout
- Remove unnecessary `-mx-6`/`px-6` overflow wrapper around Servicios table

## Testing
- Open Historial → search input should be vertically centered with filter buttons and date selector
- Open Servicios y Precios → layout should match Historial's spacing and font
- Compare both views side by side for visual consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)