### PR TITLE
feat: Structured medication fields + consultation form redesign

### DIFF
--- a/.changeset/structured-medication-fields.md
+++ b/.changeset/structured-medication-fields.md
@@ -1,0 +1,12 @@
+---
+"@coongro/consultations": minor
+---
+
+Structured medication fields and consultation form redesign
+
+- Replace free-text dosage/frequency/duration with structured columns
+- Add route (via) field for medication administration
+- Shared medication constants exported for cross-plugin use
+- Consultation form: collapsible clinical exam, unified notes, services always visible
+- Auto-prefill weight from patient record
+- Section icons and receipt-style service lines

--- a/design/frequency-input.svg
+++ b/design/frequency-input.svg
@@ -1,0 +1,121 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 380" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .text-label { fill: #6B6660; font-size: 10px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-value { fill: #2C2925; font-size: 12px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .input-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .chip-active { fill: #FFF8E7; stroke: #F5A800; stroke-width: 1; rx: 10; }
+      .chip-inactive { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 10; }
+      .chip-text-active { fill: #8A6800; font-size: 10px; font-weight: 500; }
+      .chip-text-inactive { fill: #9B9893; font-size: 10px; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .separator { stroke: #E5E2DC; stroke-width: 1; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 600; letter-spacing: 0.5px; }
+      .text-title { fill: #2C2925; font-size: 13px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+      .suffix { fill: #9B9893; font-size: 11px; }
+    </style>
+  </defs>
+
+  <rect width="520" height="380" class="bg" rx="8"/>
+
+  <text x="16" y="24" class="text-title">Frecuencia — Input con presets</text>
+  <line x1="0" y1="34" x2="520" y2="34" class="separator"/>
+
+  <!-- ═══ ESTADO 1: Nada seleccionado ═══ -->
+  <text x="16" y="56" class="text-section">ESTADO 1: VACIO</text>
+
+  <text x="16" y="76" class="text-label">Frecuencia *</text>
+
+  <!-- Input numerico con suffix "horas" -->
+  <rect x="16" y="82" width="120" height="28" class="input-bg"/>
+  <text x="28" y="100" class="text-placeholder">Cada...</text>
+  <text x="108" y="100" class="suffix">hs</text>
+
+  <!-- Chips de presets -->
+  <rect x="146" y="84" width="34" height="22" class="chip-inactive"/>
+  <text x="163" y="99" text-anchor="middle" class="chip-text-inactive">6h</text>
+
+  <rect x="184" y="84" width="34" height="22" class="chip-inactive"/>
+  <text x="201" y="99" text-anchor="middle" class="chip-text-inactive">8h</text>
+
+  <rect x="222" y="84" width="38" height="22" class="chip-inactive"/>
+  <text x="241" y="99" text-anchor="middle" class="chip-text-inactive">12h</text>
+
+  <rect x="264" y="84" width="38" height="22" class="chip-inactive"/>
+  <text x="283" y="99" text-anchor="middle" class="chip-text-inactive">24h</text>
+
+  <rect x="306" y="84" width="38" height="22" class="chip-inactive"/>
+  <text x="325" y="99" text-anchor="middle" class="chip-text-inactive">48h</text>
+
+  <rect x="348" y="84" width="38" height="22" class="chip-inactive"/>
+  <text x="367" y="99" text-anchor="middle" class="chip-text-inactive">72h</text>
+
+  <text x="16" y="126" class="annotation">Click en un chip → llena el input. O escribir directo cualquier numero.</text>
+
+  <!-- ═══ ESTADO 2: Preset seleccionado (12h) ═══ -->
+  <line x1="0" y1="142" x2="520" y2="142" class="separator"/>
+  <text x="16" y="162" class="text-section">ESTADO 2: PRESET SELECCIONADO (click en 12h)</text>
+
+  <text x="16" y="182" class="text-label">Frecuencia *</text>
+
+  <rect x="16" y="188" width="120" height="28" class="input-bg"/>
+  <text x="28" y="206" class="text-value">12</text>
+  <text x="108" y="206" class="suffix">hs</text>
+
+  <rect x="146" y="190" width="34" height="22" class="chip-inactive"/>
+  <text x="163" y="205" text-anchor="middle" class="chip-text-inactive">6h</text>
+
+  <rect x="184" y="190" width="34" height="22" class="chip-inactive"/>
+  <text x="201" y="205" text-anchor="middle" class="chip-text-inactive">8h</text>
+
+  <rect x="222" y="190" width="38" height="22" class="chip-active"/>
+  <text x="241" y="205" text-anchor="middle" class="chip-text-active">12h</text>
+
+  <rect x="264" y="190" width="38" height="22" class="chip-inactive"/>
+  <text x="283" y="205" text-anchor="middle" class="chip-text-inactive">24h</text>
+
+  <rect x="306" y="190" width="38" height="22" class="chip-inactive"/>
+  <text x="325" y="205" text-anchor="middle" class="chip-text-inactive">48h</text>
+
+  <rect x="348" y="190" width="38" height="22" class="chip-inactive"/>
+  <text x="367" y="205" text-anchor="middle" class="chip-text-inactive">72h</text>
+
+  <text x="16" y="232" class="annotation">El chip 12h se ilumina dorado. El input muestra "12". Editable — si el vet cambia a 10, el chip se deselecciona.</text>
+
+  <!-- ═══ ESTADO 3: Valor custom (4h) ═══ -->
+  <line x1="0" y1="248" x2="520" y2="248" class="separator"/>
+  <text x="16" y="268" class="text-section">ESTADO 3: VALOR CUSTOM (el vet escribio 4)</text>
+
+  <text x="16" y="288" class="text-label">Frecuencia *</text>
+
+  <rect x="16" y="294" width="120" height="28" class="input-bg"/>
+  <text x="28" y="312" class="text-value">4</text>
+  <text x="108" y="312" class="suffix">hs</text>
+
+  <rect x="146" y="296" width="34" height="22" class="chip-inactive"/>
+  <text x="163" y="311" text-anchor="middle" class="chip-text-inactive">6h</text>
+
+  <rect x="184" y="296" width="34" height="22" class="chip-inactive"/>
+  <text x="201" y="311" text-anchor="middle" class="chip-text-inactive">8h</text>
+
+  <rect x="222" y="296" width="38" height="22" class="chip-inactive"/>
+  <text x="241" y="311" text-anchor="middle" class="chip-text-inactive">12h</text>
+
+  <rect x="264" y="296" width="38" height="22" class="chip-inactive"/>
+  <text x="283" y="311" text-anchor="middle" class="chip-text-inactive">24h</text>
+
+  <rect x="306" y="296" width="38" height="22" class="chip-inactive"/>
+  <text x="325" y="311" text-anchor="middle" class="chip-text-inactive">48h</text>
+
+  <rect x="348" y="296" width="38" height="22" class="chip-inactive"/>
+  <text x="367" y="311" text-anchor="middle" class="chip-text-inactive">72h</text>
+
+  <text x="16" y="338" class="annotation">Ningun chip activo — el valor es custom. Totalmente valido. El resumen colapsado dira "c/4h".</text>
+
+  <!-- ═══ Layout note ═══ -->
+  <line x1="0" y1="350" x2="520" y2="350" class="separator"/>
+  <text x="16" y="368" class="text-muted" font-size="9">Input + chips en una sola fila (flex wrap). En mobile los chips bajan a segunda linea. El input siempre es editable.</text>
+</svg>

--- a/design/medication-expanded-card.svg
+++ b/design/medication-expanded-card.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 340" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .card-expanded { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1.5; rx: 10; }
+      .text-label { fill: #6B6660; font-size: 10px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-value { fill: #2C2925; font-size: 12px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .input-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .select-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .compound { stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .num-part { fill: #FFFFFF; }
+      .sel-part { fill: #FAFAF8; }
+      .chip-active { fill: #FFF8E7; stroke: #F5A800; stroke-width: 1; rx: 9; }
+      .chip-inactive { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 9; }
+      .chip-text-active { fill: #8A6800; font-size: 9px; font-weight: 500; }
+      .chip-text-inactive { fill: #9B9893; font-size: 9px; }
+      .expand-icon { fill: #9B9893; font-size: 11px; }
+      .separator { stroke: #E5E2DC; stroke-width: 1; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .suffix { fill: #9B9893; font-size: 10px; }
+      .text-title { fill: #2C2925; font-size: 13px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+    </style>
+  </defs>
+
+  <rect width="620" height="340" class="bg" rx="8"/>
+
+  <text x="16" y="22" class="text-title">Card expandida — Frecuencia con chips debajo</text>
+  <line x1="0" y1="32" x2="620" y2="32" class="separator"/>
+
+  <!-- Card expandida -->
+  <rect x="10" y="42" width="600" height="286" class="card-expanded"/>
+
+  <!-- Header -->
+  <text x="26" y="64" class="expand-icon">&#9660;</text>
+  <rect x="42" y="52" width="80" height="18" rx="9" fill="#F0EDE8" stroke="none"/>
+  <text x="82" y="65" text-anchor="middle" class="text-value" font-size="10" font-weight="500">Meloxicam</text>
+  <rect x="568" y="52" width="22" height="18" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="579" y="65" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <line x1="26" y1="76" x2="596" y2="76" class="separator"/>
+
+  <!-- Nombre -->
+  <text x="26" y="94" class="text-label">Medicamento *</text>
+  <rect x="26" y="100" width="564" height="24" class="input-bg"/>
+  <text x="38" y="116" class="text-value">Meloxicam</text>
+
+  <!-- ═══ Fila: Dosis + Via + Duracion (3 columnas) ═══ -->
+
+  <!-- Dosis -->
+  <text x="26" y="142" class="text-label">Dosis *</text>
+  <rect x="26" y="148" width="170" height="24" class="compound"/>
+  <rect x="26" y="148" width="96" height="24" class="num-part" rx="6"/>
+  <text x="38" y="164" class="text-value">0.2</text>
+  <line x1="122" y1="150" x2="122" y2="170" stroke="#E5E2DC" stroke-width="1"/>
+  <rect x="122" y="148" width="74" height="24" class="sel-part" rx="0"/>
+  <text x="134" y="164" class="text-value" font-size="10">mg/kg</text>
+  <text x="186" y="164" class="text-muted" font-size="8">&#9662;</text>
+
+  <!-- Via -->
+  <text x="210" y="142" class="text-label">Via</text>
+  <rect x="210" y="148" width="100" height="24" class="select-bg"/>
+  <text x="222" y="164" class="text-value" font-size="10">SC</text>
+  <text x="300" y="164" class="text-muted" font-size="8">&#9662;</text>
+
+  <!-- Duracion -->
+  <text x="324" y="142" class="text-label">Duracion *</text>
+  <rect x="324" y="148" width="130" height="24" class="compound"/>
+  <rect x="324" y="148" width="66" height="24" class="num-part" rx="6"/>
+  <text x="336" y="164" class="text-value">3</text>
+  <line x1="390" y1="150" x2="390" y2="170" stroke="#E5E2DC" stroke-width="1"/>
+  <rect x="390" y="148" width="64" height="24" class="sel-part" rx="0"/>
+  <text x="402" y="164" class="text-value" font-size="10">dias</text>
+  <text x="444" y="164" class="text-muted" font-size="8">&#9662;</text>
+
+  <!-- ═══ Fila: Frecuencia (full width, input + chips) ═══ -->
+  <text x="26" y="192" class="text-label">Frecuencia *</text>
+
+  <!-- Input numerico con suffix -->
+  <rect x="26" y="198" width="90" height="24" class="input-bg"/>
+  <text x="38" y="214" class="text-value">12</text>
+  <text x="92" y="214" class="suffix">hs</text>
+
+  <!-- Chips de presets al lado del input -->
+  <rect x="128" y="200" width="30" height="20" class="chip-inactive"/>
+  <text x="143" y="214" text-anchor="middle" class="chip-text-inactive">6h</text>
+
+  <rect x="162" y="200" width="30" height="20" class="chip-inactive"/>
+  <text x="177" y="214" text-anchor="middle" class="chip-text-inactive">8h</text>
+
+  <rect x="196" y="200" width="34" height="20" class="chip-active"/>
+  <text x="213" y="214" text-anchor="middle" class="chip-text-active">12h</text>
+
+  <rect x="234" y="200" width="34" height="20" class="chip-inactive"/>
+  <text x="251" y="214" text-anchor="middle" class="chip-text-inactive">24h</text>
+
+  <rect x="272" y="200" width="34" height="20" class="chip-inactive"/>
+  <text x="289" y="214" text-anchor="middle" class="chip-text-inactive">48h</text>
+
+  <rect x="310" y="200" width="34" height="20" class="chip-inactive"/>
+  <text x="327" y="214" text-anchor="middle" class="chip-text-inactive">72h</text>
+
+  <!-- ═══ Notas ═══ -->
+  <text x="26" y="240" class="text-label">Notas</text>
+  <rect x="26" y="246" width="564" height="22" class="input-bg"/>
+  <text x="38" y="261" class="text-placeholder" font-size="10">Indicaciones para este medicamento...</text>
+
+  <!-- Preview -->
+  <rect x="26" y="276" width="564" height="16" rx="4" fill="#F6F5F1" stroke="none"/>
+  <text x="38" y="288" class="text-muted" font-size="9">Vista colapsada: Meloxicam · 0.2 mg/kg · SC · c/12h · 3 dias</text>
+
+  <!-- Annotation -->
+  <text x="26" y="320" class="annotation">Frecuencia en fila propia (full width). Input 90px + 6 chips = ~350px total. Entra holgado. En mobile wrappean naturalmente.</text>
+</svg>

--- a/design/medication-form-v1.svg
+++ b/design/medication-form-v1.svg
@@ -1,0 +1,176 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .card { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 12; }
+      .text-title { fill: #2C2925; font-size: 14px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 600; letter-spacing: 0.5px; }
+      .text-label { fill: #6B6660; font-size: 10px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .text-value { fill: #2C2925; font-size: 12px; }
+      .input-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .select-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .row-bg { fill: #FAFAF8; stroke: #E5E2DC; stroke-width: 1; rx: 8; }
+      .btn-primary { fill: #F5A800; rx: 6; }
+      .btn-primary-text { fill: #FFFFFF; font-size: 11px; font-weight: 500; }
+      .btn-outline { fill: none; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .btn-outline-text { fill: #6B6660; font-size: 11px; }
+      .separator { stroke: #E5E2DC; stroke-width: 1; }
+      .badge { fill: #E3F2FD; rx: 3; }
+      .badge-text { fill: #1565C0; font-size: 8px; font-weight: 600; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .compound { stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .num-part { fill: #FFFFFF; }
+      .sel-part { fill: #FAFAF8; }
+    </style>
+  </defs>
+
+  <rect width="720" height="520" class="bg" rx="8"/>
+
+  <!-- Header -->
+  <text x="20" y="28" class="text-title">Medicamentos — v1 Compact Inline</text>
+  <text x="700" y="28" text-anchor="end" class="text-muted">Variante 1</text>
+  <line x1="0" y1="40" x2="720" y2="40" class="separator"/>
+
+  <!-- Descripcion -->
+  <text x="20" y="58" class="annotation">Evolucion del formulario actual. Misma estructura en fila, pero con campos estructurados (numero + select) en vez de texto libre.</text>
+  <text x="20" y="70" class="annotation">Cada campo compuesto es un input partido: parte izquierda numerica, parte derecha select de unidad.</text>
+
+  <!-- ═══ Column headers ═══ -->
+  <text x="20" y="96" class="text-section">MEDICAMENTO *</text>
+  <text x="195" y="96" class="text-section">DOSIS *</text>
+  <text x="338" y="96" class="text-section">VIA</text>
+  <text x="418" y="96" class="text-section">FRECUENCIA *</text>
+  <text x="540" y="96" class="text-section">DURACION *</text>
+  <text x="665" y="96" class="text-section">NOTAS</text>
+
+  <!-- ═══ Medicamento 1 ═══ -->
+  <rect x="12" y="104" width="696" height="56" class="row-bg"/>
+
+  <!-- Nombre -->
+  <rect x="20" y="112" width="165" height="30" class="input-bg"/>
+  <text x="30" y="131" class="text-value">Amoxicilina</text>
+
+  <!-- Dosis: compound [numero | unidad] -->
+  <rect x="193" y="112" width="135" height="30" class="compound"/>
+  <rect x="193" y="112" width="65" height="30" class="num-part" rx="6"/>
+  <text x="203" y="131" class="text-value">15</text>
+  <line x1="258" y1="114" x2="258" y2="140" stroke="#E5E2DC" stroke-width="1"/>
+  <rect x="258" y="112" width="70" height="30" class="sel-part" rx="0"/>
+  <text x="268" y="131" class="text-value" font-size="11">mg/kg</text>
+  <text x="316" y="131" class="text-muted" font-size="9">&#9662;</text>
+
+  <!-- Via -->
+  <rect x="336" y="112" width="74" height="30" class="select-bg"/>
+  <text x="346" y="131" class="text-value" font-size="11">Oral</text>
+  <text x="400" y="131" class="text-muted" font-size="9">&#9662;</text>
+
+  <!-- Frecuencia: select estandarizado -->
+  <rect x="416" y="112" width="115" height="30" class="select-bg"/>
+  <text x="426" y="131" class="text-value" font-size="11">Cada 12 hs</text>
+  <text x="520" y="131" class="text-muted" font-size="9">&#9662;</text>
+
+  <!-- Duracion: compound [numero | unidad] -->
+  <rect x="538" y="112" width="115" height="30" class="compound"/>
+  <rect x="538" y="112" width="55" height="30" class="num-part" rx="6"/>
+  <text x="548" y="131" class="text-value">7</text>
+  <line x1="593" y1="114" x2="593" y2="140" stroke="#E5E2DC" stroke-width="1"/>
+  <rect x="593" y="112" width="60" height="30" class="sel-part" rx="0"/>
+  <text x="603" y="131" class="text-value" font-size="11">dias</text>
+  <text x="643" y="131" class="text-muted" font-size="9">&#9662;</text>
+
+  <!-- Notas icon + delete -->
+  <rect x="661" y="112" width="24" height="30" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="673" y="131" text-anchor="middle" fill="#9B9893" font-size="12">&#9998;</text>
+  <rect x="689" y="112" width="24" height="30" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="701" y="131" text-anchor="middle" fill="#C8423A" font-size="13">x</text>
+
+  <!-- ═══ Medicamento 2 (vacio) ═══ -->
+  <rect x="12" y="168" width="696" height="56" class="row-bg"/>
+
+  <rect x="20" y="176" width="165" height="30" class="input-bg"/>
+  <text x="30" y="195" class="text-placeholder">Ej: Amoxicilina</text>
+
+  <rect x="193" y="176" width="135" height="30" class="compound"/>
+  <rect x="193" y="176" width="65" height="30" class="num-part" rx="6"/>
+  <text x="203" y="195" class="text-placeholder">0</text>
+  <line x1="258" y1="178" x2="258" y2="204" stroke="#E5E2DC" stroke-width="1"/>
+  <rect x="258" y="176" width="70" height="30" class="sel-part" rx="0"/>
+  <text x="268" y="195" class="text-placeholder" font-size="10">mg/kg</text>
+  <text x="316" y="195" class="text-muted" font-size="9">&#9662;</text>
+
+  <rect x="336" y="176" width="74" height="30" class="select-bg"/>
+  <text x="346" y="195" class="text-placeholder" font-size="10">Via</text>
+  <text x="400" y="195" class="text-muted" font-size="9">&#9662;</text>
+
+  <rect x="416" y="176" width="115" height="30" class="select-bg"/>
+  <text x="426" y="195" class="text-placeholder" font-size="10">Frecuencia</text>
+  <text x="520" y="195" class="text-muted" font-size="9">&#9662;</text>
+
+  <rect x="538" y="176" width="115" height="30" class="compound"/>
+  <rect x="538" y="176" width="55" height="30" class="num-part" rx="6"/>
+  <text x="548" y="195" class="text-placeholder">0</text>
+  <line x1="593" y1="178" x2="593" y2="204" stroke="#E5E2DC" stroke-width="1"/>
+  <rect x="593" y="176" width="60" height="30" class="sel-part" rx="0"/>
+  <text x="603" y="195" class="text-placeholder" font-size="10">dias</text>
+  <text x="643" y="195" class="text-muted" font-size="9">&#9662;</text>
+
+  <rect x="689" y="176" width="24" height="30" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="701" y="195" text-anchor="middle" fill="#C8423A" font-size="13">x</text>
+
+  <!-- Boton agregar -->
+  <rect x="12" y="232" width="696" height="30" rx="6" fill="none" stroke="#E5E2DC" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="360" y="251" text-anchor="middle" class="text-muted">+ Agregar medicamento</text>
+
+  <!-- ═══ Leyenda ═══ -->
+  <line x1="0" y1="280" x2="720" y2="280" class="separator"/>
+  <text x="20" y="300" class="text-section">CAMPOS ESTRUCTURADOS</text>
+
+  <!-- Dosis -->
+  <rect x="20" y="312" width="180" height="54" rx="6" fill="#FAFAF8" stroke="#E5E2DC" stroke-width="0.5"/>
+  <text x="30" y="330" class="text-label" font-weight="600">Dosis (compound input)</text>
+  <text x="30" y="344" class="annotation">Parte izq: numero (decimal permitido)</text>
+  <text x="30" y="356" class="annotation">Parte der: select unidad</text>
+
+  <!-- Unidades dosis -->
+  <text x="215" y="330" class="text-label" font-weight="600">Unidades de dosis</text>
+  <text x="215" y="344" class="text-muted">mg/kg · mg · ml · UI/kg · gotas · comp.</text>
+  <rect x="215" y="350" width="55" height="13" class="badge"/>
+  <text x="220" y="360" class="badge-text">ORTODOXO</text>
+  <text x="278" y="360" class="annotation">Unidades estandar veterinarias</text>
+
+  <!-- Via -->
+  <rect x="20" y="376" width="180" height="54" rx="6" fill="#FAFAF8" stroke="#E5E2DC" stroke-width="0.5"/>
+  <text x="30" y="394" class="text-label" font-weight="600">Via (select)</text>
+  <text x="30" y="408" class="annotation">Oral · IM · IV · SC · Topica</text>
+  <text x="30" y="420" class="annotation">Oftalmica · Otica</text>
+
+  <!-- Frecuencia -->
+  <rect x="215" y="376" width="180" height="54" rx="6" fill="#FAFAF8" stroke="#E5E2DC" stroke-width="0.5"/>
+  <text x="225" y="394" class="text-label" font-weight="600">Frecuencia (select presets)</text>
+  <text x="225" y="408" class="annotation">Cada 6h · 8h · 12h · 24h · 48h · 72h</text>
+  <text x="225" y="420" class="annotation">Texto claro, sin abreviaturas SID/BID</text>
+
+  <!-- Duracion -->
+  <rect x="410" y="376" width="180" height="54" rx="6" fill="#FAFAF8" stroke="#E5E2DC" stroke-width="0.5"/>
+  <text x="420" y="394" class="text-label" font-weight="600">Duracion (compound input)</text>
+  <text x="420" y="408" class="annotation">Parte izq: numero entero</text>
+  <text x="420" y="420" class="annotation">Parte der: dias · semanas · meses</text>
+
+  <!-- Auto-fill note -->
+  <line x1="0" y1="444" x2="720" y2="444" class="separator"/>
+  <text x="20" y="464" class="text-section">AUTO-FILL (cuando vet-pharmacy esta instalado)</text>
+  <text x="20" y="480" class="annotation">Si vet-pharmacy esta instalado y tiene catalogo, al seleccionar medicamento se precargan: dosis default, via, presentacion.</text>
+  <text x="20" y="492" class="annotation">Sin vet-pharmacy, todos los campos son manuales pero estructurados (numero + select en vez de texto libre).</text>
+
+  <!-- Pro/Con -->
+  <text x="420" y="464" class="text-label" font-weight="600">Pros</text>
+  <text x="420" y="478" class="annotation">Compacto, familiar, facil de escanear multiples meds</text>
+  <text x="420" y="490" class="annotation">Minima curva de aprendizaje vs formulario actual</text>
+  <text x="560" y="464" class="text-label" font-weight="600">Contras</text>
+  <text x="560" y="478" class="annotation">Puede sentirse apretado en mobile</text>
+  <text x="560" y="490" class="annotation">Notas relegadas a icono</text>
+
+  <text x="20" y="512" class="text-muted">consultations/design/medication-form-v1.svg — Compact Inline</text>
+</svg>

--- a/design/medication-form-v2.svg
+++ b/design/medication-form-v2.svg
@@ -1,0 +1,170 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 880" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .card { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 12; }
+      .text-title { fill: #2C2925; font-size: 14px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 600; letter-spacing: 0.5px; }
+      .text-label { fill: #6B6660; font-size: 10px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .text-value { fill: #2C2925; font-size: 12px; }
+      .input-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .select-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .med-card { fill: #FAFAF8; stroke: #E5E2DC; stroke-width: 1; rx: 10; }
+      .btn-primary { fill: #F5A800; rx: 6; }
+      .btn-primary-text { fill: #FFFFFF; font-size: 11px; font-weight: 500; }
+      .separator { stroke: #E5E2DC; stroke-width: 1; }
+      .badge { fill: #E3F2FD; rx: 3; }
+      .badge-text { fill: #1565C0; font-size: 8px; font-weight: 600; }
+      .badge-ortho { fill: #F0FAF4; rx: 3; }
+      .badge-ortho-text { fill: #3D9A5C; font-size: 8px; font-weight: 600; }
+      .badge-auto { fill: #E8F5E9; rx: 3; }
+      .badge-auto-text { fill: #3D9A5C; font-size: 8px; font-weight: 600; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .compound { stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .num-part { fill: #FFFFFF; }
+      .sel-part { fill: #FAFAF8; }
+    </style>
+  </defs>
+
+  <rect width="540" height="880" class="bg" rx="8"/>
+
+  <!-- Header -->
+  <text x="20" y="28" class="text-title">Medicamentos — v2 Card Expandida</text>
+  <text x="520" y="28" text-anchor="end" class="text-muted">Variante 2</text>
+  <line x1="0" y1="40" x2="540" y2="40" class="separator"/>
+
+  <text x="20" y="58" class="annotation">Cada medicamento como card individual con campos organizados en grid 2x3. Mas espacio, mejor legibilidad, ideal para 1-3 meds.</text>
+
+  <!-- ═══ Medicamento 1 — Card ═══ -->
+  <rect x="14" y="72" width="512" height="310" class="med-card"/>
+
+  <!-- Card header -->
+  <text x="28" y="94" class="text-section">MEDICAMENTO 1</text>
+  <rect x="480" y="80" width="24" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="492" y="94" text-anchor="middle" fill="#C8423A" font-size="12">x</text>
+
+  <!-- Nombre -->
+  <text x="28" y="114" class="text-label">Nombre del medicamento *</text>
+  <rect x="28" y="120" width="484" height="30" class="input-bg"/>
+  <text x="40" y="139" class="text-value">Amoxicilina</text>
+  <text x="28" y="162" class="annotation">Texto libre — el buscador con catalogo lo inyecta vet-pharmacy via view contributions</text>
+
+  <!-- Fila 1: Dosis + Via + (placeholder presentacion) -->
+  <text x="28" y="182" class="text-label">Dosis *</text>
+  <rect x="28" y="188" width="170" height="30" class="compound"/>
+  <rect x="28" y="188" width="90" height="30" class="num-part" rx="6"/>
+  <text x="40" y="207" class="text-value">15</text>
+  <line x1="118" y1="190" x2="118" y2="216" stroke="#E5E2DC" stroke-width="1"/>
+  <rect x="118" y="188" width="80" height="30" class="sel-part" rx="0"/>
+  <text x="130" y="207" class="text-value" font-size="11">mg/kg</text>
+  <text x="186" y="207" class="text-muted" font-size="9">&#9662;</text>
+  <rect x="28" y="220" width="55" height="12" class="badge-ortho"/>
+  <text x="32" y="230" class="badge-ortho-text">ORTODOXO</text>
+
+  <text x="210" y="182" class="text-label">Via de administracion</text>
+  <rect x="210" y="188" width="140" height="30" class="select-bg"/>
+  <text x="222" y="207" class="text-value" font-size="11">Oral</text>
+  <text x="338" y="207" class="text-muted" font-size="9">&#9662;</text>
+  <rect x="210" y="220" width="55" height="12" class="badge-ortho"/>
+  <text x="214" y="230" class="badge-ortho-text">ORTODOXO</text>
+
+  <!-- Presentacion (solo visible si vet-pharmacy instalado) -->
+  <text x="362" y="182" class="text-label">Presentacion</text>
+  <rect x="362" y="188" width="150" height="30" rx="6" fill="#F6F5F1" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="374" y="207" class="text-muted" font-size="10">Comp. 500mg</text>
+  <text x="374" y="230" class="annotation">Read-only (del catalogo)</text>
+
+  <!-- Fila 2: Frecuencia + Duracion -->
+  <text x="28" y="252" class="text-label">Frecuencia *</text>
+  <rect x="28" y="258" width="170" height="30" class="select-bg"/>
+  <text x="40" y="277" class="text-value" font-size="11">Cada 12 horas</text>
+  <text x="186" y="277" class="text-muted" font-size="9">&#9662;</text>
+  <rect x="28" y="290" width="55" height="12" class="badge-ortho"/>
+  <text x="32" y="300" class="badge-ortho-text">ORTODOXO</text>
+  <text x="90" y="300" class="annotation">Presets: 6h, 8h, 12h, 24h, 48h, 72h</text>
+
+  <text x="210" y="252" class="text-label">Duracion *</text>
+  <rect x="210" y="258" width="140" height="30" class="compound"/>
+  <rect x="210" y="258" width="70" height="30" class="num-part" rx="6"/>
+  <text x="222" y="277" class="text-value">7</text>
+  <line x1="280" y1="260" x2="280" y2="286" stroke="#E5E2DC" stroke-width="1"/>
+  <rect x="280" y="258" width="70" height="30" class="sel-part" rx="0"/>
+  <text x="290" y="277" class="text-value" font-size="11">dias</text>
+  <text x="340" y="277" class="text-muted" font-size="9">&#9662;</text>
+
+  <!-- Notas -->
+  <text x="362" y="252" class="text-label">Notas (opcional)</text>
+  <rect x="362" y="258" width="150" height="30" class="input-bg"/>
+  <text x="374" y="277" class="text-placeholder" font-size="10">Indicaciones...</text>
+
+  <!-- Resumen inline -->
+  <rect x="28" y="316" width="484" height="22" rx="4" fill="#F6F5F1" stroke="none"/>
+  <text x="40" y="331" class="text-muted" font-size="10">Resumen: Amoxicilina 15 mg/kg · Oral · Cada 12h · 7 dias</text>
+  <rect x="408" y="320" width="55" height="14" class="badge"/>
+  <text x="435" y="331" class="badge-text" text-anchor="middle">PREVIEW</text>
+  <text x="40" y="346" class="annotation">Linea de resumen auto-generada — util para escaneo rapido en la lista de medicamentos</text>
+
+  <!-- Fila 2: Frecuencia + Duracion bottom annotations -->
+  <text x="210" y="300" class="annotation">dias · semanas · meses</text>
+
+  <!-- ═══ Medicamento 2 — Vacio ═══ -->
+  <rect x="14" y="394" width="512" height="100" class="med-card" stroke-dasharray="4 2"/>
+
+  <text x="28" y="416" class="text-section">MEDICAMENTO 2</text>
+
+  <text x="28" y="436" class="text-label">Nombre del medicamento *</text>
+  <rect x="28" y="442" width="484" height="30" class="input-bg"/>
+  <text x="40" y="461" class="text-placeholder">Ej: Amoxicilina, Meloxicam...</text>
+
+  <text x="28" y="484" class="annotation">Los campos de dosis, via, frecuencia y duracion aparecen al ingresar el nombre</text>
+
+  <!-- Boton agregar -->
+  <rect x="14" y="506" width="512" height="30" rx="6" fill="none" stroke="#E5E2DC" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="270" y="525" text-anchor="middle" class="text-muted">+ Agregar medicamento</text>
+
+  <!-- ═══ Especificaciones ═══ -->
+  <line x1="0" y1="552" x2="540" y2="552" class="separator"/>
+  <text x="20" y="572" class="text-section">CAMPOS ORTODOXOS (estandar veterinario)</text>
+
+  <!-- Grid de specs -->
+  <rect x="20" y="582" width="245" height="44" rx="4" fill="#F0FAF4" stroke="#B8D4A0" stroke-width="0.5"/>
+  <text x="30" y="598" class="text-label" font-weight="600">Dosis = cantidad + unidad</text>
+  <text x="30" y="614" class="annotation">mg/kg | mg | ml | UI/kg | gotas | comp.</text>
+
+  <rect x="275" y="582" width="245" height="44" rx="4" fill="#F0FAF4" stroke="#B8D4A0" stroke-width="0.5"/>
+  <text x="285" y="598" class="text-label" font-weight="600">Via = ruta de administracion</text>
+  <text x="285" y="614" class="annotation">Oral | IM | IV | SC | Topica | Oftalmica | Otica</text>
+
+  <rect x="20" y="634" width="245" height="44" rx="4" fill="#F0FAF4" stroke="#B8D4A0" stroke-width="0.5"/>
+  <text x="30" y="650" class="text-label" font-weight="600">Frecuencia = intervalo en horas</text>
+  <text x="30" y="666" class="annotation">Presets: c/6h | c/8h | c/12h | c/24h | c/48h | c/72h</text>
+
+  <rect x="275" y="634" width="245" height="44" rx="4" fill="#F0FAF4" stroke="#B8D4A0" stroke-width="0.5"/>
+  <text x="285" y="650" class="text-label" font-weight="600">Duracion = cantidad + unidad</text>
+  <text x="285" y="666" class="annotation">dias | semanas | meses</text>
+
+  <!-- Auto-fill section -->
+  <text x="20" y="700" class="text-section">AUTO-FILL (cross-plugin)</text>
+
+  <rect x="20" y="710" width="500" height="56" rx="4" fill="#FAFAF8" stroke="#E5E2DC" stroke-width="0.5"/>
+  <text x="30" y="728" class="text-label" font-weight="600">Consultations (este plugin):</text>
+  <text x="30" y="742" class="annotation">Nombre del medicamento es texto libre. Campos de dosis/via/frecuencia/duracion son estructurados.</text>
+  <text x="30" y="754" class="annotation">El veterinario ingresa todo manualmente — numero + selecciona unidad del select.</text>
+
+  <rect x="20" y="774" width="500" height="40" rx="4" fill="#E8F5E9" stroke="#B8D4A0" stroke-width="0.5"/>
+  <text x="30" y="792" class="text-label" font-weight="600">Con vet-pharmacy (addon):</text>
+  <text x="30" y="804" class="annotation">Reemplaza el input de nombre por un buscador con catalogo via view contributions. Precarga dosis/via.</text>
+
+  <!-- Pro/Con -->
+  <text x="20" y="836" class="text-label" font-weight="600">Pros</text>
+  <text x="20" y="848" class="annotation">Campos visibles de un vistazo, espacio para notas, linea de resumen auto-generada</text>
+  <text x="20" y="860" class="annotation">Responsive natural (cada card stackea a columna en mobile)</text>
+
+  <text x="300" y="836" class="text-label" font-weight="600">Contras</text>
+  <text x="300" y="848" class="annotation">Ocupa mas espacio vertical, puede sentirse pesado con 5+ meds</text>
+  <text x="300" y="860" class="annotation">Card vacia es visualmente grande antes de llenarse</text>
+
+  <text x="20" y="878" class="text-muted">consultations/design/medication-form-v2.svg — Card Expandida</text>
+</svg>

--- a/design/medication-form-v3.svg
+++ b/design/medication-form-v3.svg
@@ -1,0 +1,446 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 1820" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .card { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 12; }
+      .card-collapsible { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 12; }
+      .card-collapsed { fill: #FAFAF8; stroke: #E5E2DC; stroke-width: 1; rx: 12; }
+      .text-title { fill: #2C2925; font-size: 14px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 600; letter-spacing: 0.5px; }
+      .text-label { fill: #6B6660; font-size: 10px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .text-value { fill: #2C2925; font-size: 12px; }
+      .input-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .select-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .row-bg { fill: #FAFAF8; stroke: #E5E2DC; stroke-width: 1; rx: 8; }
+      .row-expanded { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1.5; rx: 10; }
+      .separator { stroke: #E5E2DC; stroke-width: 1; }
+      .chip-active { fill: #FFF8E7; stroke: #F5A800; stroke-width: 1; rx: 12; }
+      .chip-inactive { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 12; }
+      .chip-text-active { fill: #8A6800; font-size: 11px; font-weight: 500; }
+      .chip-text-inactive { fill: #9B9893; font-size: 11px; }
+      .badge-change { fill: #FFF3CC; rx: 3; }
+      .badge-change-text { fill: #8A6800; font-size: 7px; font-weight: 600; }
+      .badge-auto { fill: #E8F5E9; rx: 3; }
+      .badge-auto-text { fill: #3D9A5C; font-size: 7px; font-weight: 600; }
+      .badge-new { fill: #E3F2FD; rx: 3; }
+      .badge-new-text { fill: #1565C0; font-size: 7px; font-weight: 600; }
+      .badge-merged { fill: #E3F2FD; rx: 3; }
+      .badge-merged-text { fill: #1565C0; font-size: 7px; font-weight: 600; }
+      .badge-removed { fill: #FFEBEE; rx: 3; }
+      .badge-removed-text { fill: #C8423A; font-size: 7px; font-weight: 600; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .compound { stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .num-part { fill: #FFFFFF; }
+      .sel-part { fill: #FAFAF8; }
+      .expand-icon { fill: #9B9893; font-size: 11px; }
+      .summary-text { fill: #6B6660; font-size: 10px; }
+      .prefilled-bg { fill: #FAFFF7; stroke: #B8D4A0; stroke-width: 1; rx: 6; }
+      .strikethrough { text-decoration: line-through; fill: #C8423A; font-size: 10px; }
+      .collapse-chevron { fill: #9B9893; font-size: 12px; cursor: pointer; }
+      .section-icon { fill: none; stroke: #9B9893; stroke-width: 1.4; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <rect width="640" height="1820" class="bg" rx="8"/>
+
+  <!-- ═══ Header ═══ -->
+  <text x="20" y="28" class="text-title">Formulario de consulta — v3 Rediseño completo</text>
+  <text x="620" y="28" text-anchor="end" class="text-muted">v3.1</text>
+  <line x1="0" y1="40" x2="640" y2="40" class="separator"/>
+  <text x="20" y="58" class="annotation">Campos redundantes eliminados, examen clinico colapsable, servicios siempre visibles, medicacion estructurada</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- SECCION 1: DATOS BASICOS                                      -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="72" width="612" height="136" class="card"/>
+  <!-- Icono ClipboardList (Lucide) -->
+  <g transform="translate(28, 80) scale(0.583)" class="section-icon">
+    <rect width="8" height="4" x="8" y="2" rx="1" ry="1"/>
+    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>
+    <path d="M12 11h4"/><path d="M12 16h4"/>
+    <path d="M8 11h.01"/><path d="M8 16h.01"/>
+  </g>
+  <text x="46" y="94" class="text-section">DATOS BASICOS</text>
+  <line x1="138" y1="90" x2="612" y2="90" class="separator"/>
+
+  <!-- Veterinario — autocomplete -->
+  <text x="28" y="114" class="text-label">Veterinario *</text>
+  <rect x="28" y="120" width="290" height="28" class="select-bg"/>
+  <text x="40" y="138" class="text-value">Dra. Martinez</text>
+  <text x="306" y="138" class="text-muted" font-size="9">&#9662;</text>
+  <rect x="228" y="110" width="78" height="12" class="badge-auto"/>
+  <text x="232" y="119" class="badge-auto-text">AUTOCOMPLETE</text>
+  <text x="28" y="160" class="annotation">Select de veterinarios del tenant (contacts). Fallback a texto libre. Default del settings.</text>
+
+  <!-- Fecha -->
+  <text x="336" y="114" class="text-label">Fecha y hora</text>
+  <rect x="336" y="120" width="276" height="28" class="input-bg"/>
+  <text x="348" y="138" class="text-value">28/03/2026 10:30</text>
+
+  <!-- Peso — precargado -->
+  <text x="28" y="178" class="text-label">Peso (kg)</text>
+  <rect x="28" y="184" width="140" height="28" class="prefilled-bg"/>
+  <text x="40" y="202" class="text-value">28.5</text>
+  <rect x="100" y="172" width="62" height="12" class="badge-auto"/>
+  <text x="104" y="181" class="badge-auto-text">PRECARGADO</text>
+
+  <!-- Temperatura -->
+  <text x="186" y="178" class="text-label">Temperatura (°C)</text>
+  <rect x="186" y="184" width="132" height="28" class="input-bg"/>
+  <text x="198" y="202" class="text-placeholder">ej: 38.5</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- SECCION 2: SERVICIOS PRESTADOS — siempre visible              -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="220" width="612" height="106" class="card"/>
+  <!-- Icono Receipt (Lucide) -->
+  <g transform="translate(28, 228) scale(0.583)" class="section-icon">
+    <path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1-2 1Z"/>
+    <path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8"/>
+    <path d="M12 17.5v-11"/>
+  </g>
+  <text x="46" y="242" class="text-section">SERVICIOS PRESTADOS</text>
+  <rect x="173" y="232" width="55" height="12" class="badge-change"/>
+  <text x="177" y="241" class="badge-change-text">CAMBIADO</text>
+  <line x1="236" y1="238" x2="612" y2="238" class="separator"/>
+
+  <!-- Motivo como input corto -->
+  <text x="28" y="258" class="text-label">Motivo (1 linea) *</text>
+  <rect x="28" y="264" width="584" height="28" class="input-bg"/>
+  <text x="40" y="282" class="text-value">Control anual de rutina</text>
+
+  <!-- ServiceLineForm placeholder -->
+  <rect x="28" y="300" width="584" height="22" rx="4" fill="#FAFAF8" stroke="#E5E2DC" stroke-width="0.5"/>
+  <text x="40" y="315" class="text-muted" font-size="9">ServiceLineForm: catalogo de servicios + precios (columnas de precio controladas por showPrices)</text>
+
+  <text x="28" y="324" class="annotation">Chips de categoria eliminados — redundantes con los servicios. showPrices solo oculta columnas de precio.</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- SECCION 3: EXAMEN CLINICO — colapsable, cerrado por defecto   -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+
+  <!-- Estado colapsado (default) -->
+  <rect x="14" y="372" width="612" height="40" class="card-collapsed"/>
+  <text x="28" y="396" class="collapse-chevron">&#9654;</text>
+  <!-- Icono Stethoscope (Lucide) -->
+  <g transform="translate(40, 382) scale(0.583)" class="section-icon">
+    <path d="M11 2v2"/><path d="M5 2v2"/>
+    <path d="M5 3H4a2 2 0 0 0-2 2v4a6 6 0 0 0 12 0V5a2 2 0 0 0-2-2h-1"/>
+    <path d="M8 15a6 6 0 0 0 12 0v-3"/>
+    <circle cx="20" cy="10" r="2"/>
+  </g>
+  <text x="58" y="396" class="text-section">EXAMEN CLINICO</text>
+  <rect x="150" y="386" width="55" height="12" class="badge-change"/>
+  <text x="154" y="395" class="badge-change-text">COLAPSABLE</text>
+  <text x="215" y="396" class="text-muted" font-size="9">Anamnesis · Examen fisico</text>
+  <text x="596" y="396" class="text-muted" font-size="9">Abrir</text>
+
+  <text x="28" y="426" class="annotation">Cerrado por defecto. Para vacunas, seguimientos y visitas rapidas no se necesita. El vet abre solo si hace examen completo.</text>
+
+  <!-- Estado expandido (al hacer click) -->
+  <rect x="14" y="442" width="612" height="150" class="card-collapsible"/>
+  <text x="28" y="464" class="collapse-chevron">&#9660;</text>
+  <g transform="translate(40, 450) scale(0.583)" class="section-icon">
+    <path d="M11 2v2"/><path d="M5 2v2"/>
+    <path d="M5 3H4a2 2 0 0 0-2 2v4a6 6 0 0 0 12 0V5a2 2 0 0 0-2-2h-1"/>
+    <path d="M8 15a6 6 0 0 0 12 0v-3"/>
+    <circle cx="20" cy="10" r="2"/>
+  </g>
+  <text x="58" y="464" class="text-section">EXAMEN CLINICO</text>
+  <text x="596" y="464" class="text-muted" font-size="9">Cerrar</text>
+  <line x1="28" y1="472" x2="612" y2="472" class="separator"/>
+
+  <text x="28" y="492" class="text-label">Anamnesis</text>
+  <rect x="28" y="498" width="584" height="28" class="input-bg"/>
+  <text x="40" y="516" class="text-placeholder">Lo que reporta el dueno...</text>
+
+  <text x="28" y="540" class="text-label">Examen fisico</text>
+  <rect x="28" y="546" width="584" height="28" class="input-bg"/>
+  <text x="40" y="564" class="text-placeholder">Hallazgos del examen...</text>
+
+  <text x="28" y="586" class="annotation">Ambos campos opcionales. Si se completan, se muestran en la vista de detalle.</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- SECCION 4: DIAGNOSTICO — con diagnosis_tags                   -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="604" width="612" height="104" class="card"/>
+  <!-- Icono SearchCheck (Lucide) -->
+  <g transform="translate(28, 612) scale(0.583)" class="section-icon">
+    <path d="m8 11 2 2 4-4"/>
+    <circle cx="11" cy="11" r="8"/>
+    <path d="m21 21-4.3-4.3"/>
+  </g>
+  <text x="46" y="626" class="text-section">DIAGNOSTICO</text>
+  <line x1="125" y1="622" x2="612" y2="622" class="separator"/>
+
+  <text x="28" y="646" class="text-label">Diagnostico</text>
+  <rect x="28" y="652" width="584" height="28" class="input-bg"/>
+  <text x="40" y="670" class="text-value">Paciente clinicamente sano</text>
+
+  <!-- diagnosis_tags — NUEVO en el form -->
+  <text x="28" y="694" class="text-label">Tags de diagnostico</text>
+  <rect x="28" y="700" width="584" height="28" rx="6" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1"/>
+  <rect x="34" y="704" width="48" height="18" rx="9" fill="#F0EDE8" stroke="none"/>
+  <text x="58" y="717" text-anchor="middle" class="text-value" font-size="9">sano</text>
+  <rect x="88" y="704" width="58" height="18" rx="9" fill="#F0EDE8" stroke="none"/>
+  <text x="117" y="717" text-anchor="middle" class="text-value" font-size="9">control</text>
+  <text x="156" y="717" class="text-placeholder" font-size="10">Agregar tag...</text>
+  <rect x="28" y="730" width="45" height="12" class="badge-new"/>
+  <text x="32" y="739" class="badge-new-text">NUEVO</text>
+  <text x="80" y="739" class="annotation">ChipInput. Campo diagnosis_tags (jsonb) existia en DB pero no en el form. Util para filtrar historial.</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- SECCION 5: TRATAMIENTO + MEDICACION                          -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="752" width="612" height="366" class="card"/>
+  <!-- Icono Pill (Lucide) -->
+  <g transform="translate(28, 760) scale(0.583)" class="section-icon">
+    <path d="m10.5 20.5 10-10a4.95 4.95 0 1 0-7-7l-10 10a4.95 4.95 0 1 0 7 7Z"/>
+    <path d="m8.5 8.5 7 7"/>
+  </g>
+  <text x="46" y="774" class="text-section">TRATAMIENTO</text>
+  <rect x="120" y="764" width="55" height="12" class="badge-change"/>
+  <text x="124" y="773" class="badge-change-text">CAMBIADO</text>
+  <line x1="183" y1="770" x2="612" y2="770" class="separator"/>
+
+  <!-- Indicaciones generales -->
+  <text x="28" y="794" class="text-label">Indicaciones generales</text>
+  <rect x="28" y="800" width="584" height="28" class="input-bg"/>
+  <text x="40" y="818" class="text-value">Dieta blanda 3 dias, reposo relativo</text>
+  <text x="28" y="838" class="annotation">Renombrado de "Plan de tratamiento". Indicaciones no farmacologicas. Los farmacos van en Medicacion.</text>
+
+  <!-- ─── Medicamentos: Hibrido collapse/expand ─── -->
+  <text x="28" y="858" class="text-label" font-weight="600">Medicacion</text>
+
+  <!-- Med 1 — colapsado -->
+  <rect x="28" y="868" width="584" height="38" class="row-bg"/>
+  <text x="42" y="892" class="expand-icon">&#9654;</text>
+  <rect x="58" y="878" width="96" height="18" rx="9" fill="#F0EDE8" stroke="none"/>
+  <text x="106" y="891" text-anchor="middle" class="text-value" font-size="10" font-weight="500">Amoxicilina</text>
+  <text x="166" y="891" class="summary-text">15 mg/kg</text>
+  <text x="218" y="891" class="text-muted">·</text>
+  <text x="226" y="891" class="summary-text">Oral</text>
+  <text x="250" y="891" class="text-muted">·</text>
+  <text x="258" y="891" class="summary-text">c/12h</text>
+  <text x="290" y="891" class="text-muted">·</text>
+  <text x="298" y="891" class="summary-text">7 dias</text>
+  <rect x="572" y="878" width="22" height="18" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="583" y="891" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <!-- Med 2 — expandido -->
+  <rect x="28" y="914" width="584" height="160" class="row-expanded"/>
+
+  <text x="42" y="936" class="expand-icon">&#9660;</text>
+  <rect x="58" y="924" width="80" height="18" rx="9" fill="#F0EDE8" stroke="none"/>
+  <text x="98" y="937" text-anchor="middle" class="text-value" font-size="10" font-weight="500">Meloxicam</text>
+  <rect x="572" y="924" width="22" height="18" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="583" y="937" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <line x1="42" y1="948" x2="598" y2="948" class="separator"/>
+
+  <!-- Nombre -->
+  <text x="42" y="966" class="text-label">Medicamento *</text>
+  <rect x="42" y="972" width="556" height="24" class="input-bg"/>
+  <text x="54" y="988" class="text-value">Meloxicam</text>
+
+  <!-- Dosis + Via + Frecuencia + Duracion -->
+  <text x="42" y="1010" class="text-label">Dosis *</text>
+  <rect x="42" y="1016" width="140" height="24" class="compound"/>
+  <rect x="42" y="1016" width="74" height="24" class="num-part" rx="6"/>
+  <text x="54" y="1032" class="text-value">0.2</text>
+  <line x1="116" y1="1018" x2="116" y2="1038" stroke="#E5E2DC" stroke-width="1"/>
+  <rect x="116" y="1016" width="66" height="24" class="sel-part" rx="0"/>
+  <text x="126" y="1032" class="text-value" font-size="10">mg/kg</text>
+  <text x="172" y="1032" class="text-muted" font-size="8">&#9662;</text>
+
+  <text x="194" y="1010" class="text-label">Via</text>
+  <rect x="194" y="1016" width="80" height="24" class="select-bg"/>
+  <text x="206" y="1032" class="text-value" font-size="10">SC</text>
+  <text x="264" y="1032" class="text-muted" font-size="8">&#9662;</text>
+
+  <text x="286" y="1010" class="text-label">Frecuencia *</text>
+  <rect x="286" y="1016" width="120" height="24" class="select-bg"/>
+  <text x="298" y="1032" class="text-value" font-size="10">Cada 24 horas</text>
+  <text x="396" y="1032" class="text-muted" font-size="8">&#9662;</text>
+
+  <text x="418" y="1010" class="text-label">Duracion *</text>
+  <rect x="418" y="1016" width="110" height="24" class="compound"/>
+  <rect x="418" y="1016" width="54" height="24" class="num-part" rx="6"/>
+  <text x="430" y="1032" class="text-value">3</text>
+  <line x1="472" y1="1018" x2="472" y2="1038" stroke="#E5E2DC" stroke-width="1"/>
+  <rect x="472" y="1016" width="56" height="24" class="sel-part" rx="0"/>
+  <text x="482" y="1032" class="text-value" font-size="10">dias</text>
+  <text x="518" y="1032" class="text-muted" font-size="8">&#9662;</text>
+
+  <!-- Notas med -->
+  <text x="42" y="1056" class="text-label">Notas</text>
+  <rect x="42" y="1062" width="556" height="22" class="input-bg"/>
+  <text x="54" y="1077" class="text-placeholder" font-size="10">Indicaciones para este medicamento...</text>
+
+  <!-- Boton agregar med -->
+  <rect x="28" y="1082" width="584" height="26" rx="6" fill="none" stroke="#E5E2DC" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="320" y="1099" text-anchor="middle" class="text-muted" font-size="10">+ Agregar medicamento</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- SECCION 6: ADJUNTOS — NUEVO                                   -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="1130" width="612" height="72" class="card"/>
+  <!-- Icono Paperclip (Lucide) -->
+  <g transform="translate(28, 1138) scale(0.583)" class="section-icon">
+    <path d="M13.234 20.252 21 12.3"/>
+    <path d="m16 6-8.414 8.586a2 2 0 0 0 0 2.828 2 2 0 0 0 2.828 0l8.414-8.586a4 4 0 0 0 0-5.656 4 4 0 0 0-5.656 0l-8.415 8.585a6 6 0 1 0 8.486 8.486"/>
+  </g>
+  <text x="46" y="1152" class="text-section">ADJUNTOS</text>
+  <rect x="92" y="1142" width="45" height="12" class="badge-new"/>
+  <text x="96" y="1151" class="badge-new-text">NUEVO</text>
+  <line x1="145" y1="1148" x2="612" y2="1148" class="separator"/>
+
+  <rect x="28" y="1162" width="584" height="30" rx="6" fill="none" stroke="#E5E2DC" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="320" y="1181" text-anchor="middle" class="text-muted" font-size="10">Arrastra archivos o haz click para adjuntar (fotos, radiografias, lab...)</text>
+  <text x="28" y="1200" class="annotation">Campo attachments (jsonb) existia en DB pero no en el form. Fotos, radiografias, resultados de laboratorio.</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- SECCION 7: SEGUIMIENTO — unificado                           -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="1214" width="612" height="88" class="card"/>
+  <!-- Icono CalendarCheck (Lucide) -->
+  <g transform="translate(28, 1222) scale(0.583)" class="section-icon">
+    <path d="M8 2v4"/><path d="M16 2v4"/>
+    <rect width="18" height="18" x="3" y="4" rx="2"/>
+    <path d="M3 10h18"/>
+    <path d="m9 16 2 2 4-4"/>
+  </g>
+  <text x="46" y="1236" class="text-section">SEGUIMIENTO</text>
+  <rect x="120" y="1226" width="50" height="12" class="badge-merged"/>
+  <text x="124" y="1235" class="badge-merged-text">UNIFICADO</text>
+  <line x1="178" y1="1232" x2="612" y2="1232" class="separator"/>
+
+  <!-- Proximo control -->
+  <text x="28" y="1256" class="text-label">Proximo control</text>
+  <rect x="28" y="1262" width="160" height="28" class="input-bg"/>
+  <text x="40" y="1280" class="text-value">04/04/2026</text>
+
+  <!-- Notas unificadas -->
+  <text x="200" y="1256" class="text-label">Notas</text>
+  <rect x="200" y="1262" width="412" height="28" class="input-bg"/>
+  <text x="212" y="1280" class="text-value">Verificar peso en proximo control</text>
+  <text x="28" y="1300" class="annotation">Antes: "Notas de seguimiento" + "Notas generales" separados. Ahora: un solo campo.</text>
+
+  <!-- ═══ Footer botones ═══ -->
+  <rect x="14" y="1314" width="612" height="48" class="card"/>
+  <rect x="490" y="1326" width="120" height="28" rx="6" fill="#F5A800"/>
+  <text x="550" y="1344" text-anchor="middle" fill="#FFFFFF" font-size="12" font-weight="500">Registrar consulta</text>
+  <rect x="388" y="1326" width="90" height="28" rx="6" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="433" y="1344" text-anchor="middle" class="text-muted" font-size="12">Cancelar</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- RESUMEN DE CAMBIOS                                            -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <line x1="0" y1="1378" x2="640" y2="1378" class="separator"/>
+  <text x="20" y="1398" class="text-title">Resumen de cambios</text>
+
+  <rect x="20" y="1412" width="600" height="20" rx="0" fill="#F0EDE8" stroke="none"/>
+  <text x="30" y="1426" class="text-label" font-weight="600">Campo</text>
+  <text x="200" y="1426" class="text-label" font-weight="600">Antes</text>
+  <text x="420" y="1426" class="text-label" font-weight="600">Despues</text>
+
+  <!-- 1 -->
+  <text x="30" y="1448" class="text-label">Veterinario</text>
+  <text x="200" y="1448" class="text-muted">Texto libre</text>
+  <text x="420" y="1448" class="text-value" font-size="10">Autocomplete contacts</text>
+  <rect x="570" y="1440" width="45" height="12" class="badge-auto"/>
+  <text x="574" y="1449" class="badge-auto-text">AUTO-FILL</text>
+
+  <!-- 2 -->
+  <text x="30" y="1466" class="text-label">Peso</text>
+  <text x="200" y="1466" class="text-muted">Vacio cada vez</text>
+  <text x="420" y="1466" class="text-value" font-size="10">Precargado ultimo registro</text>
+  <rect x="570" y="1458" width="45" height="12" class="badge-auto"/>
+  <text x="574" y="1467" class="badge-auto-text">AUTO-FILL</text>
+
+  <!-- 3 -->
+  <text x="30" y="1484" class="text-label">Motivo + Servicios</text>
+  <text x="200" y="1484" class="text-muted">2 secciones + chips categ.</text>
+  <text x="420" y="1484" class="text-value" font-size="10">1 seccion. Sin chips. Siempre visible.</text>
+  <rect x="570" y="1476" width="45" height="12" class="badge-merged"/>
+  <text x="574" y="1485" class="badge-merged-text">UNIFICADO</text>
+
+  <!-- 4 -->
+  <text x="30" y="1502" class="text-label">Examen clinico</text>
+  <text x="200" y="1502" class="text-muted">Siempre abierto</text>
+  <text x="420" y="1502" class="text-value" font-size="10">Colapsable (cerrado default)</text>
+  <rect x="570" y="1494" width="55" height="12" class="badge-change"/>
+  <text x="574" y="1503" class="badge-change-text">CAMBIADO</text>
+
+  <!-- 5 -->
+  <text x="30" y="1520" class="text-label">Diagnostico tags</text>
+  <text x="200" y="1520" class="text-muted">No estaba en form</text>
+  <text x="420" y="1520" class="text-value" font-size="10">ChipInput (jsonb existente)</text>
+  <rect x="570" y="1512" width="45" height="12" class="badge-new"/>
+  <text x="574" y="1521" class="badge-new-text">NUEVO</text>
+
+  <!-- 6 -->
+  <text x="30" y="1538" class="text-label">Tratamiento</text>
+  <text x="200" y="1538" class="text-muted">Textarea ambiguo</text>
+  <text x="420" y="1538" class="text-value" font-size="10">Indicaciones no farmacologicas</text>
+  <rect x="570" y="1530" width="55" height="12" class="badge-change"/>
+  <text x="574" y="1539" class="badge-change-text">CAMBIADO</text>
+
+  <!-- 7 -->
+  <text x="30" y="1556" class="text-label">Medicacion</text>
+  <text x="200" y="1556" class="text-muted">4 inputs texto libre</text>
+  <text x="420" y="1556" class="text-value" font-size="10">Estructurado + collapse/expand</text>
+  <rect x="570" y="1548" width="55" height="12" class="badge-change"/>
+  <text x="574" y="1557" class="badge-change-text">CAMBIADO</text>
+
+  <!-- 8 -->
+  <text x="30" y="1574" class="text-label">Adjuntos</text>
+  <text x="200" y="1574" class="text-muted">No estaba en form</text>
+  <text x="420" y="1574" class="text-value" font-size="10">Upload zone (jsonb existente)</text>
+  <rect x="570" y="1566" width="45" height="12" class="badge-new"/>
+  <text x="574" y="1575" class="badge-new-text">NUEVO</text>
+
+  <!-- 9 -->
+  <text x="30" y="1592" class="text-label">Notas seguimiento</text>
+  <text x="200" y="1592" class="strikethrough">2 campos separados</text>
+  <text x="420" y="1592" class="text-value" font-size="10">1 campo unificado</text>
+  <rect x="570" y="1584" width="45" height="12" class="badge-merged"/>
+  <text x="574" y="1593" class="badge-merged-text">UNIFICADO</text>
+
+  <!-- ═══ Campos estructurados de medicacion ═══ -->
+  <line x1="0" y1="1610" x2="640" y2="1610" class="separator"/>
+  <text x="20" y="1630" class="text-section">CAMPOS ESTRUCTURADOS DE MEDICACION</text>
+
+  <rect x="20" y="1640" width="145" height="36" rx="4" fill="#F0FAF4" stroke="#B8D4A0" stroke-width="0.5"/>
+  <text x="30" y="1654" class="text-label" font-size="9" font-weight="600">Dosis</text>
+  <text x="30" y="1668" class="annotation">numeric + select</text>
+
+  <rect x="175" y="1640" width="145" height="36" rx="4" fill="#F0FAF4" stroke="#B8D4A0" stroke-width="0.5"/>
+  <text x="185" y="1654" class="text-label" font-size="9" font-weight="600">Via</text>
+  <text x="185" y="1668" class="annotation">Oral|IM|IV|SC|Top|Oft|Ot</text>
+
+  <rect x="330" y="1640" width="145" height="36" rx="4" fill="#F0FAF4" stroke="#B8D4A0" stroke-width="0.5"/>
+  <text x="340" y="1654" class="text-label" font-size="9" font-weight="600">Frecuencia</text>
+  <text x="340" y="1668" class="annotation">c/6h|8h|12h|24h|48h|72h</text>
+
+  <rect x="485" y="1640" width="135" height="36" rx="4" fill="#F0FAF4" stroke="#B8D4A0" stroke-width="0.5"/>
+  <text x="495" y="1654" class="text-label" font-size="9" font-weight="600">Duracion</text>
+  <text x="495" y="1668" class="annotation">int + dias|sem|meses</text>
+
+  <text x="20" y="1698" class="text-label" font-size="9">Unidades de dosis:</text>
+  <text x="120" y="1698" class="text-muted" font-size="9">mg/kg · mg · ml · UI/kg · gotas · comp.</text>
+
+  <!-- ═══ Notas de disenio ═══ -->
+  <line x1="0" y1="1714" x2="640" y2="1714" class="separator"/>
+  <text x="20" y="1734" class="text-section">NOTAS DE DISENIO</text>
+
+  <text x="20" y="1752" class="text-muted" font-size="9">1. Veterinario: Select de contacts si esta instalado. Fallback texto libre. Default del settings.</text>
+  <text x="20" y="1766" class="text-muted" font-size="9">2. Peso: Precargado del ultimo peso en ficha del paciente (patients). Editable si cambio.</text>
+  <text x="20" y="1780" class="text-muted" font-size="9">3. Servicios Prestados siempre visible. showPrices solo controla columnas precio/subtotal en ServiceLineForm.</text>
+  <text x="20" y="1794" class="text-muted" font-size="9">4. Examen clinico colapsable (cerrado default). Vets lo abren solo si hacen examen completo. Campos opcionales.</text>
+  <text x="20" y="1808" class="text-muted" font-size="9">5. diagnosis_tags y attachments: campos jsonb que existian en DB pero no en el form. Ahora expuestos.</text>
+
+  <text x="20" y="1820" class="text-muted">consultations/design/medication-form-v3.svg — v3.1 Rediseño completo</text>
+</svg>

--- a/design/services-section.svg
+++ b/design/services-section.svg
@@ -1,0 +1,163 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 700" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .card { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 12; }
+      .text-title { fill: #2C2925; font-size: 13px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 600; letter-spacing: 0.5px; }
+      .text-label { fill: #6B6660; font-size: 10px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .text-value { fill: #2C2925; font-size: 12px; }
+      .input-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .row-bg { fill: #FAFAF8; stroke: #E5E2DC; stroke-width: 1; rx: 8; }
+      .separator { stroke: #E5E2DC; stroke-width: 1; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .badge-change { fill: #FFF3CC; rx: 3; }
+      .badge-change-text { fill: #8A6800; font-size: 7px; font-weight: 600; }
+      .badge-price { fill: #F0EDE8; rx: 3; }
+      .badge-price-text { fill: #6B6660; font-size: 9px; }
+      .total-bg { fill: #F6F5F1; stroke: none; rx: 6; }
+      .total-text { fill: #2C2925; font-size: 14px; font-weight: 700; font-family: 'Noto Serif JP', serif; }
+      .total-label { fill: #9B9893; font-size: 11px; font-weight: 500; }
+      .chip-cat { fill: #F0EDE8; stroke: none; rx: 8; }
+      .chip-cat-text { fill: #6B6660; font-size: 9px; }
+    </style>
+  </defs>
+
+  <rect width="620" height="700" class="bg" rx="8"/>
+
+  <text x="16" y="22" class="text-title">Servicios Prestados — Rediseño</text>
+  <line x1="0" y1="32" x2="620" y2="32" class="separator"/>
+
+  <!-- ═══ ANTES ═══ -->
+  <text x="16" y="52" class="text-section">ANTES (tabla tipo spreadsheet)</text>
+  <rect x="16" y="60" width="588" height="86" rx="6" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1"/>
+
+  <!-- Header tabla vieja -->
+  <rect x="16" y="60" width="588" height="20" rx="0" fill="#FAFAF8"/>
+  <text x="26" y="74" class="text-muted" font-size="9">Servicio</text>
+  <text x="350" y="74" class="text-muted" font-size="9">Cant.</text>
+  <text x="420" y="74" class="text-muted" font-size="9">Precio unit.</text>
+  <text x="520" y="74" class="text-muted" font-size="9">Subtotal</text>
+
+  <!-- Fila vieja -->
+  <text x="26" y="98" class="text-value" font-size="10">Consulta general</text>
+  <rect x="340" y="86" width="50" height="20" class="input-bg"/>
+  <text x="360" y="100" class="text-value" font-size="10">1</text>
+  <rect x="410" y="86" width="70" height="20" class="input-bg"/>
+  <text x="425" y="100" class="text-value" font-size="10">5000.00</text>
+  <text x="530" y="100" class="text-value" font-size="10">$5,000</text>
+  <text x="580" y="100" fill="#C8423A" font-size="11">x</text>
+
+  <!-- Fila vieja 2 -->
+  <text x="26" y="122" class="text-value" font-size="10">Vacuna antirrabica</text>
+  <rect x="340" y="110" width="50" height="20" class="input-bg"/>
+  <text x="360" y="124" class="text-value" font-size="10">1</text>
+  <rect x="410" y="110" width="70" height="20" class="input-bg"/>
+  <text x="425" y="124" class="text-value" font-size="10">3500.00</text>
+  <text x="530" y="124" class="text-value" font-size="10">$3,500</text>
+  <text x="580" y="124" fill="#C8423A" font-size="11">x</text>
+
+  <text x="16" y="158" class="annotation">Problemas: parece planilla de calculo, inputs apretados, no respeta el design system, precios como inputs editables expuestos</text>
+
+  <!-- ═══ DESPUES ═══ -->
+  <line x1="0" y1="172" x2="620" y2="172" class="separator"/>
+  <text x="16" y="192" class="text-section">DESPUES (filas limpias, jerarquia clara)</text>
+  <rect x="16" y="196" width="55" height="12" class="badge-change"/>
+  <text x="20" y="205" class="badge-change-text">REDISEÑO</text>
+
+  <!-- Buscador -->
+  <rect x="16" y="216" width="588" height="32" rx="6" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1"/>
+  <circle cx="34" cy="232" r="7" fill="none" stroke="#C4C0BA" stroke-width="1.2"/>
+  <line x1="39" y1="237" x2="43" y2="241" fill="none" stroke="#C4C0BA" stroke-width="1.2" stroke-linecap="round"/>
+  <text x="52" y="236" class="text-placeholder">Buscar servicio para agregar...</text>
+
+  <!-- Servicio 1 -->
+  <rect x="16" y="258" width="588" height="50" class="row-bg"/>
+
+  <!-- Nombre prominente -->
+  <text x="30" y="280" class="text-value" font-weight="500">Consulta general</text>
+  <rect x="150" y="270" width="70" height="16" class="chip-cat"/>
+  <text x="185" y="281" text-anchor="middle" class="chip-cat-text">Consultas</text>
+
+  <!-- Cantidad compacta -->
+  <text x="390" y="275" class="text-muted" font-size="9">Cant.</text>
+  <rect x="390" y="280" width="40" height="20" class="input-bg"/>
+  <text x="406" y="294" text-anchor="middle" class="text-value" font-size="11">1</text>
+
+  <!-- Precio (sutil, controlado por showPrices) -->
+  <text x="446" y="288" class="badge-price-text">$5,000</text>
+
+  <!-- Eliminar -->
+  <rect x="572" y="276" width="22" height="22" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="583" y="291" text-anchor="middle" fill="#C8423A" font-size="11">x</text>
+
+  <!-- Servicio 2 -->
+  <rect x="16" y="316" width="588" height="50" class="row-bg"/>
+
+  <text x="30" y="338" class="text-value" font-weight="500">Vacuna antirrábica</text>
+  <rect x="170" y="328" width="78" height="16" class="chip-cat"/>
+  <text x="209" y="339" text-anchor="middle" class="chip-cat-text">Vacunación</text>
+
+  <text x="390" y="333" class="text-muted" font-size="9">Cant.</text>
+  <rect x="390" y="338" width="40" height="20" class="input-bg"/>
+  <text x="406" y="352" text-anchor="middle" class="text-value" font-size="11">1</text>
+
+  <text x="446" y="346" class="badge-price-text">$3,500</text>
+
+  <rect x="572" y="334" width="22" height="22" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="583" y="349" text-anchor="middle" fill="#C8423A" font-size="11">x</text>
+
+  <!-- Servicio 3 (cantidad > 1) -->
+  <rect x="16" y="374" width="588" height="50" class="row-bg"/>
+
+  <text x="30" y="396" class="text-value" font-weight="500">Análisis de sangre completo</text>
+  <rect x="220" y="386" width="72" height="16" class="chip-cat"/>
+  <text x="256" y="397" text-anchor="middle" class="chip-cat-text">Laboratorio</text>
+
+  <text x="390" y="391" class="text-muted" font-size="9">Cant.</text>
+  <rect x="390" y="396" width="40" height="20" class="input-bg"/>
+  <text x="406" y="410" text-anchor="middle" class="text-value" font-size="11">2</text>
+
+  <text x="446" y="404" class="badge-price-text">$7,000</text>
+  <text x="446" y="414" class="text-muted" font-size="8">2 × $3,500</text>
+
+  <rect x="572" y="392" width="22" height="22" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="583" y="407" text-anchor="middle" fill="#C8423A" font-size="11">x</text>
+
+  <!-- Total -->
+  <rect x="380" y="434" width="224" height="32" class="total-bg"/>
+  <text x="396" y="455" class="total-label">Total:</text>
+  <text x="590" y="456" text-anchor="end" class="total-text">$15,500</text>
+
+  <!-- ═══ NOTAS ═══ -->
+  <line x1="0" y1="484" x2="620" y2="484" class="separator"/>
+  <text x="16" y="504" class="text-section">DIFERENCIAS CLAVE</text>
+
+  <!-- Grid comparativo -->
+  <rect x="16" y="514" width="285" height="54" rx="4" fill="#FFEBEE" stroke="#E5E2DC" stroke-width="0.5"/>
+  <text x="26" y="530" class="text-label" font-weight="600">Antes</text>
+  <text x="26" y="544" class="annotation">Grid rigido tipo spreadsheet</text>
+  <text x="26" y="556" class="annotation">Precio unit. como input editable expuesto</text>
+
+  <rect x="319" y="514" width="285" height="54" rx="4" fill="#E8F5E9" stroke="#B8D4A0" stroke-width="0.5"/>
+  <text x="329" y="530" class="text-label" font-weight="600">Despues</text>
+  <text x="329" y="544" class="annotation">Filas limpias con nombre prominente + chip categoria</text>
+  <text x="329" y="556" class="annotation">Precio como texto sutil (no input), solo cantidad editable</text>
+
+  <rect x="16" y="576" width="285" height="42" rx="4" fill="#FFEBEE" stroke="#E5E2DC" stroke-width="0.5"/>
+  <text x="26" y="592" class="annotation">Encabezados de tabla (Servicio, Cant., Precio, Subtotal)</text>
+  <text x="26" y="604" class="annotation">Parece planilla de calculo, no app profesional</text>
+
+  <rect x="319" y="576" width="285" height="42" rx="4" fill="#E8F5E9" stroke="#B8D4A0" stroke-width="0.5"/>
+  <text x="329" y="592" class="annotation">Sin encabezados de tabla — cada fila se explica sola</text>
+  <text x="329" y="604" class="annotation">Total alineado a la derecha, tipografia Noto Serif</text>
+
+  <!-- showPrices note -->
+  <rect x="16" y="630" width="588" height="36" rx="4" fill="#FAFAF8" stroke="#E5E2DC" stroke-width="0.5"/>
+  <text x="26" y="648" class="text-label" font-weight="600">showPrices = false</text>
+  <text x="26" y="660" class="annotation">Se ocultan: precio ("$5,000"), desglose ("2 × $3,500"), y el total. Solo queda: nombre + chip + cantidad + eliminar.</text>
+
+  <text x="16" y="692" class="text-muted">consultations/design/services-section.svg — Rediseño Servicios Prestados</text>
+</svg>

--- a/design/services-v1-chips.svg
+++ b/design/services-v1-chips.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 480" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .text-title { fill: #2C2925; font-size: 13px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 600; letter-spacing: 0.5px; }
+      .text-label { fill: #6B6660; font-size: 10px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .text-value { fill: #2C2925; font-size: 12px; }
+      .input-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .separator { stroke: #E5E2DC; stroke-width: 1; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .chip-svc { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 14; }
+      .chip-svc-text { fill: #2C2925; font-size: 11px; }
+      .chip-qty { fill: #F0EDE8; rx: 8; }
+      .chip-qty-text { fill: #6B6660; font-size: 9px; font-weight: 500; }
+      .chip-price { fill: none; }
+      .chip-price-text { fill: #9B9893; font-size: 9px; }
+      .total-bg { fill: #F6F5F1; stroke: none; rx: 6; }
+      .total-text { fill: #2C2925; font-size: 14px; font-weight: 700; font-family: 'Noto Serif JP', serif; }
+      .total-label { fill: #9B9893; font-size: 11px; font-weight: 500; }
+    </style>
+  </defs>
+
+  <rect width="620" height="480" class="bg" rx="8"/>
+
+  <text x="16" y="22" class="text-title">Servicios — v1 Chips</text>
+  <text x="604" y="22" text-anchor="end" class="text-muted">Variante 1</text>
+  <line x1="0" y1="32" x2="620" y2="32" class="separator"/>
+  <text x="16" y="50" class="annotation">Servicios como chips removibles (similar a tags). Compacto, visual, familiar. Cantidad como badge dentro del chip.</text>
+
+  <!-- Card contenedora -->
+  <rect x="16" y="60" width="588" height="240" rx="10" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1"/>
+
+  <text x="30" y="84" class="text-section">SERVICIOS PRESTADOS</text>
+  <line x1="155" y1="80" x2="590" y2="80" class="separator"/>
+
+  <!-- Motivo -->
+  <text x="30" y="100" class="text-label">Motivo *</text>
+  <rect x="30" y="106" width="560" height="26" class="input-bg"/>
+  <text x="42" y="123" class="text-value">Control anual de rutina</text>
+
+  <!-- Buscador -->
+  <rect x="30" y="142" width="560" height="28" rx="6" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1"/>
+  <circle cx="46" cy="156" r="6" fill="none" stroke="#C4C0BA" stroke-width="1"/>
+  <line x1="50" y1="160" x2="53" y2="163" fill="none" stroke="#C4C0BA" stroke-width="1" stroke-linecap="round"/>
+  <text x="60" y="160" class="text-placeholder">Agregar servicio...</text>
+
+  <!-- Chips de servicios seleccionados -->
+  <rect x="30" y="180" width="560" height="66" rx="6" fill="#FAFAF8" stroke="none"/>
+
+  <!-- Chip 1: Consulta general -->
+  <rect x="38" y="188" width="180" height="28" class="chip-svc"/>
+  <text x="52" y="206" class="chip-svc-text">Consulta general</text>
+  <rect x="170" y="193" width="22" height="16" class="chip-qty"/>
+  <text x="181" y="205" text-anchor="middle" class="chip-qty-text">x1</text>
+  <text x="200" y="206" class="chip-price-text">$5,000</text>
+  <!-- X para remover -->
+  <text x="210" y="200" fill="#C4C0BA" font-size="9" cursor="pointer">✕</text>
+
+  <!-- Chip 2: Vacuna antirrabica -->
+  <rect x="228" y="188" width="190" height="28" class="chip-svc"/>
+  <text x="242" y="206" class="chip-svc-text">Vacuna antirrábica</text>
+  <rect x="372" y="193" width="22" height="16" class="chip-qty"/>
+  <text x="383" y="205" text-anchor="middle" class="chip-qty-text">x1</text>
+  <text x="402" y="206" class="chip-price-text">$3,500</text>
+  <text x="412" y="200" fill="#C4C0BA" font-size="9" cursor="pointer">✕</text>
+
+  <!-- Chip 3: Analisis de sangre (cant > 1) -->
+  <rect x="38" y="222" width="226" height="28" class="chip-svc"/>
+  <text x="52" y="240" class="chip-svc-text">Análisis de sangre completo</text>
+  <rect x="220" y="227" width="22" height="16" class="chip-qty"/>
+  <text x="231" y="239" text-anchor="middle" class="chip-qty-text">x2</text>
+  <text x="250" y="240" class="chip-price-text">$7,000</text>
+  <text x="260" y="234" fill="#C4C0BA" font-size="9" cursor="pointer">✕</text>
+
+  <!-- Total -->
+  <rect x="392" y="260" width="192" height="28" class="total-bg"/>
+  <text x="406" y="279" class="total-label">Total:</text>
+  <text x="572" y="280" text-anchor="end" class="total-text">$15,500</text>
+
+  <!-- ═══ Pros / Contras ═══ -->
+  <line x1="0" y1="316" x2="620" y2="316" class="separator"/>
+
+  <text x="16" y="336" class="text-label" font-weight="600">Pros</text>
+  <text x="16" y="350" class="annotation">Ultra compacto — 3 servicios en 2 lineas</text>
+  <text x="16" y="362" class="annotation">Familiar (patron de tags/chips comun en apps)</text>
+  <text x="16" y="374" class="annotation">Facil de escanear de un vistazo</text>
+
+  <text x="320" y="336" class="text-label" font-weight="600">Contras</text>
+  <text x="320" y="350" class="annotation">Editar cantidad requiere click extra (popover o inline edit)</text>
+  <text x="320" y="362" class="annotation">Con muchos servicios puede sentirse denso</text>
+  <text x="320" y="374" class="annotation">No hay espacio visible para notas por servicio</text>
+
+  <!-- Interaccion -->
+  <line x1="0" y1="390" x2="620" y2="390" class="separator"/>
+  <text x="16" y="410" class="text-section">INTERACCION</text>
+
+  <text x="16" y="428" class="text-muted" font-size="9">Click en chip → popover con cantidad editable + precio unitario + notas</text>
+  <text x="16" y="442" class="text-muted" font-size="9">Click en ✕ → remueve el servicio</text>
+  <text x="16" y="456" class="text-muted" font-size="9">showPrices=false → oculta "$5,000", "$7,000" y el total. Solo nombre + badge cantidad.</text>
+
+  <text x="16" y="476" class="text-muted">consultations/design/services-v1-chips.svg</text>
+</svg>

--- a/design/services-v2-rows.svg
+++ b/design/services-v2-rows.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 520" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .text-title { fill: #2C2925; font-size: 13px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 600; letter-spacing: 0.5px; }
+      .text-label { fill: #6B6660; font-size: 10px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .text-value { fill: #2C2925; font-size: 12px; }
+      .input-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .row-bg { fill: #FAFAF8; stroke: #E5E2DC; stroke-width: 1; rx: 8; }
+      .separator { stroke: #E5E2DC; stroke-width: 1; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .chip-cat { fill: #F0EDE8; stroke: none; rx: 8; }
+      .chip-cat-text { fill: #6B6660; font-size: 9px; }
+      .total-bg { fill: #F6F5F1; stroke: none; rx: 6; }
+      .total-text { fill: #2C2925; font-size: 14px; font-weight: 700; font-family: 'Noto Serif JP', serif; }
+      .total-label { fill: #9B9893; font-size: 11px; font-weight: 500; }
+    </style>
+  </defs>
+
+  <rect width="620" height="520" class="bg" rx="8"/>
+
+  <text x="16" y="22" class="text-title">Servicios — v2 Filas limpias</text>
+  <text x="604" y="22" text-anchor="end" class="text-muted">Variante 2</text>
+  <line x1="0" y1="32" x2="620" y2="32" class="separator"/>
+  <text x="16" y="50" class="annotation">Cada servicio como fila con nombre prominente, chip de categoria, cantidad inline, precio sutil. Sin headers de tabla.</text>
+
+  <!-- Card contenedora -->
+  <rect x="16" y="60" width="588" height="296" rx="10" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1"/>
+
+  <text x="30" y="84" class="text-section">SERVICIOS PRESTADOS</text>
+  <line x1="155" y1="80" x2="590" y2="80" class="separator"/>
+
+  <!-- Motivo -->
+  <text x="30" y="100" class="text-label">Motivo *</text>
+  <rect x="30" y="106" width="560" height="26" class="input-bg"/>
+  <text x="42" y="123" class="text-value">Control anual de rutina</text>
+
+  <!-- Buscador -->
+  <rect x="30" y="142" width="560" height="28" rx="6" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1"/>
+  <circle cx="46" cy="156" r="6" fill="none" stroke="#C4C0BA" stroke-width="1"/>
+  <line x1="50" y1="160" x2="53" y2="163" fill="none" stroke="#C4C0BA" stroke-width="1" stroke-linecap="round"/>
+  <text x="60" y="160" class="text-placeholder">Agregar servicio...</text>
+
+  <!-- Servicio 1 -->
+  <rect x="30" y="180" width="560" height="40" class="row-bg"/>
+  <text x="44" y="204" class="text-value" font-weight="500">Consulta general</text>
+  <rect x="160" y="194" width="70" height="16" class="chip-cat"/>
+  <text x="195" y="205" text-anchor="middle" class="chip-cat-text">Consultas</text>
+
+  <text x="420" y="198" class="text-muted" font-size="9">Cant.</text>
+  <rect x="448" y="194" width="36" height="20" class="input-bg"/>
+  <text x="466" y="208" text-anchor="middle" class="text-value" font-size="11">1</text>
+  <text x="496" y="206" class="text-muted" font-size="10">$5,000</text>
+  <rect x="556" y="194" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="208" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <!-- Servicio 2 -->
+  <rect x="30" y="226" width="560" height="40" class="row-bg"/>
+  <text x="44" y="250" class="text-value" font-weight="500">Vacuna antirrábica</text>
+  <rect x="178" y="240" width="78" height="16" class="chip-cat"/>
+  <text x="217" y="251" text-anchor="middle" class="chip-cat-text">Vacunación</text>
+
+  <text x="420" y="244" class="text-muted" font-size="9">Cant.</text>
+  <rect x="448" y="240" width="36" height="20" class="input-bg"/>
+  <text x="466" y="254" text-anchor="middle" class="text-value" font-size="11">1</text>
+  <text x="496" y="252" class="text-muted" font-size="10">$3,500</text>
+  <rect x="556" y="240" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="254" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <!-- Servicio 3 (cant > 1) -->
+  <rect x="30" y="272" width="560" height="40" class="row-bg"/>
+  <text x="44" y="296" class="text-value" font-weight="500">Análisis de sangre completo</text>
+  <rect x="232" y="286" width="72" height="16" class="chip-cat"/>
+  <text x="268" y="297" text-anchor="middle" class="chip-cat-text">Laboratorio</text>
+
+  <text x="420" y="290" class="text-muted" font-size="9">Cant.</text>
+  <rect x="448" y="286" width="36" height="20" class="input-bg"/>
+  <text x="466" y="300" text-anchor="middle" class="text-value" font-size="11">2</text>
+  <text x="496" y="296" class="text-muted" font-size="10">$7,000</text>
+  <text x="496" y="306" class="text-muted" font-size="8">2 × $3,500</text>
+  <rect x="556" y="286" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="300" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <!-- Total -->
+  <rect x="406" y="322" width="178" height="28" class="total-bg"/>
+  <text x="420" y="341" class="total-label">Total:</text>
+  <text x="572" y="342" text-anchor="end" class="total-text">$15,500</text>
+
+  <!-- ═══ Pros / Contras ═══ -->
+  <line x1="0" y1="372" x2="620" y2="372" class="separator"/>
+
+  <text x="16" y="392" class="text-label" font-weight="600">Pros</text>
+  <text x="16" y="406" class="annotation">Claro y legible — nombre grande, precio sutil</text>
+  <text x="16" y="418" class="annotation">Chip de categoria da contexto sin ocupar espacio</text>
+  <text x="16" y="430" class="annotation">Cantidad editable inline, sin click extra</text>
+  <text x="16" y="442" class="annotation">Desglose visible cuando cantidad > 1</text>
+
+  <text x="320" y="392" class="text-label" font-weight="600">Contras</text>
+  <text x="320" y="406" class="annotation">Mas vertical que v1 (1 fila por servicio)</text>
+  <text x="320" y="418" class="annotation">Con 10+ servicios puede crecer mucho</text>
+
+  <!-- showPrices -->
+  <line x1="0" y1="458" x2="620" y2="458" class="separator"/>
+  <text x="16" y="478" class="text-muted" font-size="9">showPrices=false → sin precios, sin desglose, sin total. Queda: nombre + chip categoria + cantidad + eliminar.</text>
+  <text x="16" y="492" class="text-muted" font-size="9">Precio unitario no es editable — viene del catalogo. Solo la cantidad se puede cambiar.</text>
+
+  <text x="16" y="516" class="text-muted">consultations/design/services-v2-rows.svg</text>
+</svg>

--- a/design/services-v3-compact-table.svg
+++ b/design/services-v3-compact-table.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 520" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .text-title { fill: #2C2925; font-size: 13px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 600; letter-spacing: 0.5px; }
+      .text-label { fill: #6B6660; font-size: 10px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .text-value { fill: #2C2925; font-size: 12px; }
+      .input-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .separator { stroke: #E5E2DC; stroke-width: 1; }
+      .separator-light { stroke: #F0EDE8; stroke-width: 1; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .table-surface { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 8; }
+      .table-header { fill: #FAFAF8; }
+      .total-row { fill: #F6F5F1; }
+      .total-text { fill: #2C2925; font-size: 13px; font-weight: 700; font-family: 'Noto Serif JP', serif; }
+      .total-label { fill: #9B9893; font-size: 11px; font-weight: 500; }
+    </style>
+  </defs>
+
+  <rect width="620" height="520" class="bg" rx="8"/>
+
+  <text x="16" y="22" class="text-title">Servicios — v3 Tabla compacta mejorada</text>
+  <text x="604" y="22" text-anchor="end" class="text-muted">Variante 3</text>
+  <line x1="0" y1="32" x2="620" y2="32" class="separator"/>
+  <text x="16" y="50" class="annotation">Mantiene la estructura de tabla pero refinada: sin inputs de precio, headers sutiles, bordes suaves, tipografia clara.</text>
+
+  <!-- Card contenedora -->
+  <rect x="16" y="60" width="588" height="310" rx="10" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1"/>
+
+  <text x="30" y="84" class="text-section">SERVICIOS PRESTADOS</text>
+  <line x1="155" y1="80" x2="590" y2="80" class="separator"/>
+
+  <!-- Motivo -->
+  <text x="30" y="100" class="text-label">Motivo *</text>
+  <rect x="30" y="106" width="560" height="26" class="input-bg"/>
+  <text x="42" y="123" class="text-value">Control anual de rutina</text>
+
+  <!-- Buscador -->
+  <rect x="30" y="142" width="560" height="28" rx="6" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1"/>
+  <circle cx="46" cy="156" r="6" fill="none" stroke="#C4C0BA" stroke-width="1"/>
+  <line x1="50" y1="160" x2="53" y2="163" fill="none" stroke="#C4C0BA" stroke-width="1" stroke-linecap="round"/>
+  <text x="60" y="160" class="text-placeholder">Agregar servicio...</text>
+
+  <!-- Tabla mejorada -->
+  <rect x="30" y="180" width="560" height="178" class="table-surface"/>
+
+  <!-- Header sutil (no grita) -->
+  <rect x="31" y="181" width="558" height="22" rx="0" class="table-header"/>
+  <text x="44" y="196" class="text-muted" font-size="9" font-weight="500">Servicio</text>
+  <text x="410" y="196" class="text-muted" font-size="9" font-weight="500" text-anchor="middle">Cant.</text>
+  <text x="510" y="196" class="text-muted" font-size="9" font-weight="500" text-anchor="end">Importe</text>
+
+  <!-- Fila 1 -->
+  <text x="44" y="222" class="text-value" font-size="11">Consulta general</text>
+  <rect x="392" y="210" width="36" height="20" class="input-bg"/>
+  <text x="410" y="224" text-anchor="middle" class="text-value" font-size="11">1</text>
+  <text x="510" y="222" text-anchor="end" class="text-muted" font-size="11">$5,000</text>
+  <text x="548" y="222" fill="#C8423A" font-size="10" cursor="pointer">✕</text>
+  <line x1="44" y1="234" x2="556" y2="234" class="separator-light"/>
+
+  <!-- Fila 2 -->
+  <text x="44" y="254" class="text-value" font-size="11">Vacuna antirrábica</text>
+  <rect x="392" y="242" width="36" height="20" class="input-bg"/>
+  <text x="410" y="256" text-anchor="middle" class="text-value" font-size="11">1</text>
+  <text x="510" y="254" text-anchor="end" class="text-muted" font-size="11">$3,500</text>
+  <text x="548" y="254" fill="#C8423A" font-size="10" cursor="pointer">✕</text>
+  <line x1="44" y1="266" x2="556" y2="266" class="separator-light"/>
+
+  <!-- Fila 3 -->
+  <text x="44" y="286" class="text-value" font-size="11">Análisis de sangre completo</text>
+  <rect x="392" y="274" width="36" height="20" class="input-bg"/>
+  <text x="410" y="288" text-anchor="middle" class="text-value" font-size="11">2</text>
+  <text x="510" y="286" text-anchor="end" class="text-muted" font-size="11">$7,000</text>
+  <text x="510" y="298" text-anchor="end" class="text-muted" font-size="8">2 × $3,500</text>
+  <text x="548" y="286" fill="#C8423A" font-size="10" cursor="pointer">✕</text>
+  <line x1="44" y1="306" x2="556" y2="306" class="separator-light"/>
+
+  <!-- Total -->
+  <rect x="31" y="308" width="558" height="28" rx="0" class="total-row"/>
+  <text x="392" y="327" class="total-label">Total:</text>
+  <text x="510" y="328" text-anchor="end" class="total-text">$15,500</text>
+
+  <!-- Servicios sin precio -->
+  <rect x="30" y="368" width="560" height="24" rx="0" fill="#FAFAF8" stroke="none"/>
+  <text x="44" y="384" class="text-muted" font-size="9" font-weight="500">Servicio</text>
+  <text x="510" y="384" class="text-muted" font-size="9" font-weight="500" text-anchor="end">Cant.</text>
+  <text x="44" y="404" class="text-value" font-size="11">Consulta general</text>
+  <rect x="492" y="394" width="36" height="20" class="input-bg"/>
+  <text x="510" y="408" text-anchor="middle" class="text-value" font-size="11">1</text>
+  <text x="548" y="406" fill="#C8423A" font-size="10">✕</text>
+  <text x="30" y="428" class="annotation">showPrices=false → columna "Importe" y fila total desaparecen. Solo nombre + cantidad.</text>
+
+  <!-- ═══ Pros / Contras ═══ -->
+  <line x1="0" y1="442" x2="620" y2="442" class="separator"/>
+
+  <text x="16" y="462" class="text-label" font-weight="600">Pros</text>
+  <text x="16" y="476" class="annotation">Estructura familiar para usuarios que vienen de facturacion/POS</text>
+  <text x="16" y="488" class="annotation">Alineacion vertical clara, facil de escanear precios</text>
+  <text x="16" y="500" class="annotation">Separadores sutiles (no bordes gruesos como antes)</text>
+
+  <text x="320" y="462" class="text-label" font-weight="600">Contras</text>
+  <text x="320" y="476" class="annotation">Sigue pareciendo tabla — menos "app moderna" que v1/v2</text>
+  <text x="320" y="488" class="annotation">Sin chip de categoria (no cabe en la fila sin apretar)</text>
+
+  <text x="16" y="516" class="text-muted">consultations/design/services-v3-compact-table.svg</text>
+</svg>

--- a/design/services-v4-consistent.svg
+++ b/design/services-v4-consistent.svg
@@ -1,0 +1,130 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 640" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .card { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 12; }
+      .text-title { fill: #2C2925; font-size: 13px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 600; letter-spacing: 0.5px; }
+      .text-label { fill: #6B6660; font-size: 10px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .text-value { fill: #2C2925; font-size: 12px; }
+      .input-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .row-bg { fill: #FAFAF8; stroke: #E5E2DC; stroke-width: 1; rx: 8; }
+      .separator { stroke: #E5E2DC; stroke-width: 1; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .pill { fill: #F0EDE8; stroke: none; rx: 10; }
+      .pill-text { fill: #2C2925; font-size: 10px; font-weight: 500; }
+      .summary-text { fill: #6B6660; font-size: 10px; }
+      .total-bg { fill: #F6F5F1; stroke: none; rx: 6; }
+      .total-text { fill: #2C2925; font-size: 14px; font-weight: 700; font-family: 'Noto Serif JP', serif; }
+      .total-label { fill: #9B9893; font-size: 11px; font-weight: 500; }
+    </style>
+  </defs>
+
+  <rect width="620" height="640" class="bg" rx="8"/>
+
+  <text x="16" y="22" class="text-title">Servicios — v4 Consistente con medicamentos</text>
+  <text x="604" y="22" text-anchor="end" class="text-muted">v4</text>
+  <line x1="0" y1="32" x2="620" y2="32" class="separator"/>
+  <text x="16" y="50" class="annotation">Mismo patron que medicamentos: pill del nombre + resumen inline. Solo ui-components. Sin decoracion.</text>
+
+  <!-- ═══ SECCION COMPLETA ═══ -->
+  <rect x="16" y="62" width="588" height="340" class="card"/>
+
+  <text x="30" y="86" class="text-section">SERVICIOS PRESTADOS</text>
+  <line x1="155" y1="82" x2="590" y2="82" class="separator"/>
+
+  <!-- Motivo -->
+  <text x="30" y="102" class="text-label">Motivo *</text>
+  <rect x="30" y="108" width="560" height="26" class="input-bg"/>
+  <text x="42" y="125" class="text-value">Control anual de rutina</text>
+
+  <!-- Buscador (Combobox de ui-components) -->
+  <rect x="30" y="144" width="560" height="28" rx="6" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1"/>
+  <circle cx="46" cy="158" r="6" fill="none" stroke="#C4C0BA" stroke-width="1"/>
+  <line x1="50" y1="162" x2="53" y2="165" fill="none" stroke="#C4C0BA" stroke-width="1" stroke-linecap="round"/>
+  <text x="60" y="162" class="text-placeholder">Agregar servicio...</text>
+
+  <!-- Servicio 1: fila colapsada (mismo patron que medicamento colapsado) -->
+  <rect x="30" y="182" width="560" height="38" class="row-bg"/>
+  <!-- Pill nombre -->
+  <rect x="42" y="190" width="120" height="20" class="pill"/>
+  <text x="102" y="204" text-anchor="middle" class="pill-text">Consulta general</text>
+  <!-- Resumen: cantidad · precio -->
+  <text x="174" y="204" class="summary-text">x1</text>
+  <text x="196" y="204" class="text-muted">·</text>
+  <text x="206" y="204" class="summary-text">$5,000</text>
+  <!-- Eliminar (IconButton de ui-components) -->
+  <rect x="556" y="192" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="206" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <!-- Servicio 2 -->
+  <rect x="30" y="226" width="560" height="38" class="row-bg"/>
+  <rect x="42" y="234" width="138" height="20" class="pill"/>
+  <text x="111" y="248" text-anchor="middle" class="pill-text">Vacuna antirrábica</text>
+  <text x="192" y="248" class="summary-text">x1</text>
+  <text x="212" y="248" class="text-muted">·</text>
+  <text x="222" y="248" class="summary-text">$3,500</text>
+  <rect x="556" y="236" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="250" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <!-- Servicio 3 (cantidad > 1, click para editar) -->
+  <rect x="30" y="270" width="560" height="38" class="row-bg"/>
+  <rect x="42" y="278" width="200" height="20" class="pill"/>
+  <text x="142" y="292" text-anchor="middle" class="pill-text">Análisis de sangre completo</text>
+  <text x="254" y="292" class="summary-text">x2</text>
+  <text x="274" y="292" class="text-muted">·</text>
+  <text x="284" y="292" class="summary-text">$7,000</text>
+  <text x="320" y="292" class="text-muted" font-size="9">(2 × $3,500)</text>
+  <rect x="556" y="280" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="294" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <!-- Boton agregar (dashed, mismo que medicamentos) -->
+  <rect x="30" y="316" width="560" height="26" rx="6" fill="none" stroke="#E5E2DC" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="310" y="333" text-anchor="middle" class="text-muted" font-size="10">+ Agregar servicio</text>
+
+  <!-- Total (solo si showPrices) -->
+  <rect x="392" y="352" width="192" height="28" class="total-bg"/>
+  <text x="406" y="371" class="total-label">Total:</text>
+  <text x="572" y="372" text-anchor="end" class="total-text">$15,500</text>
+
+  <!-- ═══ CLICK EN FILA → editar cantidad ═══ -->
+  <line x1="0" y1="414" x2="620" y2="414" class="separator"/>
+  <text x="16" y="434" class="text-section">CLICK EN FILA → EDITAR CANTIDAD</text>
+
+  <!-- Fila expandida (inline, no popover) -->
+  <rect x="30" y="444" width="560" height="48" rx="8" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1.5"/>
+  <rect x="42" y="454" width="200" height="20" class="pill"/>
+  <text x="142" y="468" text-anchor="middle" class="pill-text">Análisis de sangre completo</text>
+
+  <!-- Cantidad editable inline -->
+  <text x="260" y="462" class="text-label">Cant.</text>
+  <rect x="286" y="452" width="40" height="22" class="input-bg"/>
+  <text x="306" y="467" text-anchor="middle" class="text-value">2</text>
+
+  <!-- Precio unitario (read-only, solo info) -->
+  <text x="340" y="462" class="text-muted" font-size="9">× $3,500</text>
+  <text x="340" y="476" class="text-muted" font-size="9">= $7,000</text>
+
+  <rect x="556" y="454" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="468" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <text x="30" y="508" class="annotation">Click en la fila abre edicion inline (misma fila se expande). Precio unitario es read-only (del catalogo). Solo cantidad editable.</text>
+
+  <!-- ═══ showPrices = false ═══ -->
+  <line x1="0" y1="522" x2="620" y2="522" class="separator"/>
+  <text x="16" y="542" class="text-section">showPrices = false</text>
+
+  <rect x="30" y="552" width="560" height="38" class="row-bg"/>
+  <rect x="42" y="560" width="120" height="20" class="pill"/>
+  <text x="102" y="574" text-anchor="middle" class="pill-text">Consulta general</text>
+  <text x="174" y="574" class="summary-text">x1</text>
+  <rect x="556" y="562" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="576" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <text x="30" y="606" class="annotation">Sin precios: pill + cantidad + eliminar. Sin total. Misma estructura, solo menos datos.</text>
+
+  <!-- ═══ Reglas cumplidas ═══ -->
+  <text x="16" y="632" class="text-muted" font-size="9">Orden sobre decoracion ✓  Jerarquia silenciosa ✓  Compartimentacion ✓  Consistencia con medicamentos ✓  100% ui-components ✓  Noto Serif solo en total ✓</text>
+</svg>

--- a/design/services-v5-polished.svg
+++ b/design/services-v5-polished.svg
@@ -1,0 +1,191 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 720" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .card { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 12; }
+      .text-title { fill: #2C2925; font-size: 13px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 600; letter-spacing: 0.5px; }
+      .text-label { fill: #6B6660; font-size: 10px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .text-value { fill: #2C2925; font-size: 12px; }
+      .input-bg { fill: #FFFFFF; stroke: #E5E2DC; stroke-width: 1; rx: 6; }
+      .row-bg { fill: #FAFAF8; stroke: #E5E2DC; stroke-width: 0.5; rx: 8; }
+      .separator { stroke: #E5E2DC; stroke-width: 1; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .total-bg { fill: #FFF8E7; stroke: none; rx: 8; }
+      .total-text { fill: #2C2925; font-size: 15px; font-weight: 700; font-family: 'Noto Serif JP', serif; }
+      .total-label { fill: #8A6800; font-size: 11px; font-weight: 500; }
+      /* Icono de servicio — color accent muted */
+      .svc-icon { fill: none; stroke: #9B9893; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
+      /* Badge de cantidad — teal accent */
+      .qty-badge { fill: #E6F4F1; stroke: none; rx: 4; }
+      .qty-text { fill: #2A7B6B; font-size: 10px; font-weight: 600; }
+      /* Precio */
+      .price-text { fill: #6B6660; font-size: 11px; font-weight: 500; }
+      .price-detail { fill: #9B9893; font-size: 9px; }
+      /* Divider dorado sutil antes del total */
+      .gold-divider { stroke: #F5A800; stroke-width: 1; opacity: 0.3; }
+    </style>
+  </defs>
+
+  <rect width="620" height="720" class="bg" rx="8"/>
+
+  <text x="16" y="22" class="text-title">Servicios — v5 Pulido</text>
+  <text x="604" y="22" text-anchor="end" class="text-muted">v5</text>
+  <line x1="0" y1="32" x2="620" y2="32" class="separator"/>
+  <text x="16" y="50" class="annotation">Iconos Lucide por servicio, badge teal para cantidad, total con acento dorado. Tokens cg-*. 100% ui-components.</text>
+
+  <!-- ═══ SECCION COMPLETA ═══ -->
+  <rect x="16" y="62" width="588" height="370" class="card"/>
+
+  <text x="30" y="86" class="text-section">SERVICIOS PRESTADOS</text>
+  <line x1="155" y1="82" x2="590" y2="82" class="separator"/>
+
+  <!-- Motivo -->
+  <text x="30" y="102" class="text-label">Motivo *</text>
+  <rect x="30" y="108" width="560" height="26" class="input-bg"/>
+  <text x="42" y="125" class="text-value">Control anual de rutina</text>
+
+  <!-- Buscador -->
+  <rect x="30" y="144" width="560" height="30" rx="6" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1"/>
+  <circle cx="48" cy="159" r="7" fill="none" stroke="#C4C0BA" stroke-width="1.2"/>
+  <line x1="53" y1="164" x2="57" y2="168" fill="none" stroke="#C4C0BA" stroke-width="1.2" stroke-linecap="round"/>
+  <text x="64" y="163" class="text-placeholder">Agregar servicio...</text>
+
+  <!-- ─── Servicio 1: Consulta general ─── -->
+  <rect x="30" y="186" width="560" height="42" class="row-bg"/>
+
+  <!-- Icono Stethoscope (Lucide, simplificado) -->
+  <circle cx="50" cy="207" r="6" class="svc-icon"/>
+  <line x1="50" y1="213" x2="50" y2="218" class="svc-icon"/>
+  <line x1="47" y1="218" x2="53" y2="218" class="svc-icon"/>
+
+  <!-- Nombre -->
+  <text x="66" y="210" class="text-value" font-weight="500">Consulta general</text>
+
+  <!-- Badge cantidad (teal) -->
+  <rect x="430" y="199" width="28" height="18" class="qty-badge"/>
+  <text x="444" y="212" text-anchor="middle" class="qty-text">x1</text>
+
+  <!-- Precio -->
+  <text x="540" y="210" text-anchor="end" class="price-text">$5,000</text>
+
+  <!-- Eliminar -->
+  <rect x="556" y="199" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="213" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <!-- ─── Servicio 2: Vacuna antirrábica ─── -->
+  <rect x="30" y="234" width="560" height="42" class="row-bg"/>
+
+  <!-- Icono Syringe (simplificado) -->
+  <line x1="46" y1="250" x2="54" y2="262" class="svc-icon"/>
+  <line x1="44" y1="252" x2="48" y2="248" class="svc-icon"/>
+  <circle cx="55" cy="263" r="2" fill="#9B9893" stroke="none"/>
+
+  <!-- Nombre -->
+  <text x="66" y="258" class="text-value" font-weight="500">Vacuna antirrábica</text>
+
+  <!-- Badge cantidad -->
+  <rect x="430" y="247" width="28" height="18" class="qty-badge"/>
+  <text x="444" y="260" text-anchor="middle" class="qty-text">x1</text>
+
+  <!-- Precio -->
+  <text x="540" y="258" text-anchor="end" class="price-text">$3,500</text>
+
+  <!-- Eliminar -->
+  <rect x="556" y="247" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="261" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <!-- ─── Servicio 3: Análisis de sangre (x2) ─── -->
+  <rect x="30" y="282" width="560" height="48" class="row-bg"/>
+
+  <!-- Icono FlaskConical (simplificado) -->
+  <line x1="46" y1="298" x2="50" y2="310" class="svc-icon"/>
+  <line x1="54" y1="298" x2="50" y2="310" class="svc-icon"/>
+  <line x1="46" y1="298" x2="54" y2="298" class="svc-icon"/>
+  <line x1="44" y1="294" x2="46" y2="298" class="svc-icon"/>
+  <line x1="56" y1="294" x2="54" y2="298" class="svc-icon"/>
+
+  <!-- Nombre -->
+  <text x="66" y="306" class="text-value" font-weight="500">Análisis de sangre completo</text>
+
+  <!-- Badge cantidad -->
+  <rect x="430" y="296" width="28" height="18" class="qty-badge"/>
+  <text x="444" y="309" text-anchor="middle" class="qty-text">x2</text>
+
+  <!-- Precio + desglose -->
+  <text x="540" y="304" text-anchor="end" class="price-text">$7,000</text>
+  <text x="540" y="318" text-anchor="end" class="price-detail">2 × $3,500</text>
+
+  <!-- Eliminar -->
+  <rect x="556" y="296" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="310" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <!-- Boton agregar -->
+  <rect x="30" y="340" width="560" height="26" rx="6" fill="none" stroke="#E5E2DC" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="310" y="357" text-anchor="middle" class="text-muted" font-size="10">+ Agregar servicio</text>
+
+  <!-- Divider dorado sutil -->
+  <line x1="350" y1="378" x2="590" y2="378" class="gold-divider"/>
+
+  <!-- Total con fondo dorado claro -->
+  <rect x="370" y="386" width="220" height="34" class="total-bg"/>
+  <text x="388" y="408" class="total-label">Total</text>
+  <text x="578" y="409" text-anchor="end" class="total-text">$15,500</text>
+
+  <!-- ═══ CLICK EN FILA ═══ -->
+  <line x1="0" y1="444" x2="620" y2="444" class="separator"/>
+  <text x="16" y="464" class="text-section">CLICK EN FILA → EDITAR CANTIDAD</text>
+
+  <rect x="30" y="474" width="560" height="56" rx="8" fill="#FFFFFF" stroke="#E5E2DC" stroke-width="1.5"/>
+
+  <!-- Icono -->
+  <line x1="46" y1="496" x2="50" y2="508" class="svc-icon"/>
+  <line x1="54" y1="496" x2="50" y2="508" class="svc-icon"/>
+  <line x1="46" y1="496" x2="54" y2="496" class="svc-icon"/>
+  <line x1="44" y1="492" x2="46" y2="496" class="svc-icon"/>
+  <line x1="56" y1="492" x2="54" y2="496" class="svc-icon"/>
+
+  <!-- Nombre -->
+  <text x="66" y="500" class="text-value" font-weight="500">Análisis de sangre completo</text>
+
+  <!-- Cantidad editable -->
+  <text x="66" y="518" class="text-label">Cantidad</text>
+  <rect x="110" y="506" width="40" height="22" class="input-bg"/>
+  <text x="130" y="521" text-anchor="middle" class="text-value">2</text>
+
+  <!-- Precio info -->
+  <text x="166" y="518" class="text-muted" font-size="9">× $3,500 = $7,000</text>
+
+  <!-- Eliminar -->
+  <rect x="556" y="494" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="508" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <!-- ═══ showPrices = false ═══ -->
+  <line x1="0" y1="546" x2="620" y2="546" class="separator"/>
+  <text x="16" y="566" class="text-section">showPrices = false</text>
+
+  <rect x="30" y="576" width="560" height="42" class="row-bg"/>
+  <!-- Icono -->
+  <circle cx="50" cy="597" r="6" class="svc-icon"/>
+  <line x1="50" y1="603" x2="50" y2="608" class="svc-icon"/>
+  <line x1="47" y1="608" x2="53" y2="608" class="svc-icon"/>
+  <!-- Nombre -->
+  <text x="66" y="600" class="text-value" font-weight="500">Consulta general</text>
+  <!-- Badge cantidad -->
+  <rect x="430" y="589" width="28" height="18" class="qty-badge"/>
+  <text x="444" y="602" text-anchor="middle" class="qty-text">x1</text>
+  <!-- Eliminar -->
+  <rect x="556" y="589" width="20" height="20" rx="4" fill="none" stroke="#E5E2DC" stroke-width="1"/>
+  <text x="566" y="603" text-anchor="middle" fill="#C8423A" font-size="10">x</text>
+
+  <text x="30" y="634" class="annotation">Sin precios, sin desglose, sin total, sin divider dorado. Icono + nombre + badge cantidad + eliminar.</text>
+
+  <!-- ═══ Reglas ═══ -->
+  <line x1="0" y1="648" x2="620" y2="648" class="separator"/>
+  <text x="16" y="666" class="text-muted" font-size="9">Iconos: DynamicIcon (Lucide) — Stethoscope, Syringe, FlaskConical, Scissors, etc. Color --cg-text-muted (#9B9893).</text>
+  <text x="16" y="680" class="text-muted" font-size="9">Cantidad: badge teal (--cg-accent-bg + --cg-accent). Precio: text --cg-text-secondary. Total: fondo --cg-warning-bg, texto Noto Serif.</text>
+  <text x="16" y="694" class="text-muted" font-size="9">Dorado solo en divider sutil (opacity 0.3) y fondo total (FFF8E7). Un solo CTA dorado por vista: el boton "Registrar consulta".</text>
+  <text x="16" y="714" class="text-muted">consultations/design/services-v5-polished.svg</text>
+</svg>

--- a/design/services-v6-final.svg
+++ b/design/services-v6-final.svg
@@ -1,0 +1,161 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 560" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .card { fill: #FFFFFF; stroke: #E8E7E2; stroke-width: 1; rx: 18; }
+      .text-title { fill: #2C2925; font-size: 13px; font-weight: 600; font-family: 'Noto Serif JP', serif; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; }
+      .text-label { fill: #6B6660; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .text-value { fill: #2C2925; font-size: 13px; }
+      .text-name { fill: #2C2925; font-size: 13px; font-weight: 500; }
+      .input-bg { fill: #FFFFFF; stroke: #E8E7E2; stroke-width: 1; rx: 7; }
+      .search-bg { fill: #F6F5F1; stroke: #E8E7E2; stroke-width: 1; rx: 7; }
+      .separator { stroke: #E8E7E2; stroke-width: 1; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .row-svc { fill: #FAFAF8; stroke: #E8E7E2; stroke-width: 1; rx: 7; }
+      .price-text { fill: #6B6760; font-size: 12px; font-weight: 400; }
+      .price-detail { fill: #9B9893; font-size: 9px; }
+      .col-label { fill: #9B9893; font-size: 9px; font-weight: 500; }
+      .total-bg { fill: #F6F5F1; stroke: none; rx: 7; }
+      .total-value { fill: #2C2925; font-size: 15px; font-weight: 900; font-family: 'Noto Serif JP', serif; }
+      .total-label { fill: #6B6760; font-size: 11px; font-weight: 500; }
+      .icon-container { fill: #F6F5F1; stroke: none; rx: 5; }
+      .icon-stroke { fill: none; stroke: #9B9893; stroke-width: 1.4; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <rect width="620" height="560" class="bg" rx="8"/>
+
+  <text x="16" y="22" class="text-title">Servicios Prestados</text>
+  <text x="604" y="22" text-anchor="end" class="text-muted">v7</text>
+  <line x1="0" y1="32" x2="620" y2="32" class="separator"/>
+
+  <!-- ═══ CARD ═══ -->
+  <rect x="16" y="44" width="588" height="326" class="card"/>
+
+  <text x="30" y="68" class="text-section">Servicios prestados</text>
+  <line x1="30" y1="76" x2="590" y2="76" class="separator"/>
+
+  <!-- Motivo -->
+  <text x="30" y="94" class="text-label">Motivo *</text>
+  <rect x="30" y="100" width="560" height="28" class="input-bg"/>
+  <text x="42" y="118" class="text-value">Control anual de rutina</text>
+
+  <!-- Buscador -->
+  <rect x="30" y="138" width="560" height="30" class="search-bg"/>
+  <circle cx="48" cy="153" r="6" fill="none" stroke="#C4C0BA" stroke-width="1.2"/>
+  <line x1="52" y1="157" x2="56" y2="161" fill="none" stroke="#C4C0BA" stroke-width="1.2" stroke-linecap="round"/>
+  <text x="64" y="157" class="text-placeholder">Agregar servicio...</text>
+
+  <!--
+    Layout de columnas fijas:
+    x=30..40: icono (20px container)
+    x=56: nombre
+    x=420: label "Cant."
+    x=422..458: input cantidad (36px)
+    x=478..536: precio (text-anchor=end at 536)
+    x=552..574: boton eliminar (22px)
+  -->
+
+  <!-- Col labels (sutiles, una sola vez arriba de las filas) -->
+  <text x="422" y="184" class="col-label">Cant.</text>
+  <text x="536" y="184" text-anchor="end" class="col-label">Importe</text>
+
+  <!-- ─── Servicio 1 ─── -->
+  <rect x="30" y="190" width="560" height="38" class="row-svc"/>
+
+  <!-- Icono neutro: clipboard check (coherente = "servicio prestado") -->
+  <rect x="38" y="198" width="20" height="20" class="icon-container"/>
+  <rect x="43" y="201" width="10" height="14" rx="1" class="icon-stroke"/>
+  <line x1="45" y1="208" x2="47" y2="210" class="icon-stroke"/>
+  <line x1="47" y1="210" x2="51" y2="205" class="icon-stroke"/>
+
+  <!-- Nombre (x=64, alineado despues del icono) -->
+  <text x="64" y="213" class="text-name">Consulta general</text>
+
+  <!-- Cantidad input (x=422, ancho 36) -->
+  <rect x="422" y="198" width="36" height="22" class="input-bg"/>
+  <text x="440" y="213" text-anchor="middle" class="text-value" font-size="11">1</text>
+
+  <!-- Precio (x=536, text-anchor end) -->
+  <text x="536" y="213" text-anchor="end" class="price-text">$5,000</text>
+
+  <!-- Eliminar (x=552) -->
+  <rect x="552" y="198" width="22" height="22" rx="7" fill="none" stroke="#E8E7E2" stroke-width="1"/>
+  <text x="563" y="213" text-anchor="middle" fill="#C8423A" font-size="11">x</text>
+
+  <!-- ─── Servicio 2 ─── -->
+  <rect x="30" y="234" width="560" height="38" class="row-svc"/>
+
+  <rect x="38" y="242" width="20" height="20" class="icon-container"/>
+  <rect x="43" y="245" width="10" height="14" rx="1" class="icon-stroke"/>
+  <line x1="45" y1="252" x2="47" y2="254" class="icon-stroke"/>
+  <line x1="47" y1="254" x2="51" y2="249" class="icon-stroke"/>
+
+  <text x="64" y="257" class="text-name">Vacuna antirrábica</text>
+
+  <rect x="422" y="242" width="36" height="22" class="input-bg"/>
+  <text x="440" y="257" text-anchor="middle" class="text-value" font-size="11">1</text>
+
+  <text x="536" y="257" text-anchor="end" class="price-text">$3,500</text>
+
+  <rect x="552" y="242" width="22" height="22" rx="7" fill="none" stroke="#E8E7E2" stroke-width="1"/>
+  <text x="563" y="257" text-anchor="middle" fill="#C8423A" font-size="11">x</text>
+
+  <!-- ─── Servicio 3 (cantidad > 1) ─── -->
+  <rect x="30" y="278" width="560" height="44" class="row-svc"/>
+
+  <rect x="38" y="288" width="20" height="20" class="icon-container"/>
+  <rect x="43" y="291" width="10" height="14" rx="1" class="icon-stroke"/>
+  <line x1="45" y1="298" x2="47" y2="300" class="icon-stroke"/>
+  <line x1="47" y1="300" x2="51" y2="295" class="icon-stroke"/>
+
+  <text x="64" y="301" class="text-name">Análisis de sangre completo</text>
+
+  <rect x="422" y="288" width="36" height="22" class="input-bg"/>
+  <text x="440" y="303" text-anchor="middle" class="text-value" font-size="11">2</text>
+
+  <text x="536" y="297" text-anchor="end" class="price-text">$7,000</text>
+  <text x="536" y="311" text-anchor="end" class="price-detail">2 × $3,500</text>
+
+  <rect x="552" y="288" width="22" height="22" rx="7" fill="none" stroke="#E8E7E2" stroke-width="1"/>
+  <text x="563" y="303" text-anchor="middle" fill="#C8423A" font-size="11">x</text>
+
+  <!-- Boton agregar (dashed, section 4.9 del DS) -->
+  <rect x="30" y="330" width="560" height="26" rx="7" fill="#FFFFFF" stroke="#D4D3CC" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="310" y="347" text-anchor="middle" class="text-muted" font-size="10">+ Agregar servicio</text>
+
+  <!-- Total (card footer pattern: bg fondo, border-top implicito por contraste) -->
+  <rect x="380" y="362" width="210" height="30" class="total-bg"/>
+  <text x="396" y="382" class="total-label">Total</text>
+  <text x="578" y="382" text-anchor="end" class="total-value">$15,500</text>
+
+  <!-- ═══ showPrices = false ═══ -->
+  <line x1="0" y1="408" x2="620" y2="408" class="separator"/>
+  <text x="16" y="428" class="text-section">showPrices = false</text>
+
+  <rect x="30" y="438" width="560" height="38" class="row-svc"/>
+
+  <rect x="38" y="446" width="20" height="20" class="icon-container"/>
+  <rect x="43" y="449" width="10" height="14" rx="1" class="icon-stroke"/>
+  <line x1="45" y1="456" x2="47" y2="458" class="icon-stroke"/>
+  <line x1="47" y1="458" x2="51" y2="453" class="icon-stroke"/>
+
+  <text x="64" y="461" class="text-name">Consulta general</text>
+
+  <rect x="422" y="446" width="36" height="22" class="input-bg"/>
+  <text x="440" y="461" text-anchor="middle" class="text-value" font-size="11">1</text>
+
+  <rect x="552" y="446" width="22" height="22" rx="7" fill="none" stroke="#E8E7E2" stroke-width="1"/>
+  <text x="563" y="461" text-anchor="middle" fill="#C8423A" font-size="11">x</text>
+
+  <text x="30" y="494" class="annotation">Sin columna de importe, sin total. Icono + nombre + cantidad + eliminar.</text>
+
+  <!-- ═══ NOTAS ═══ -->
+  <line x1="0" y1="510" x2="620" y2="510" class="separator"/>
+  <text x="16" y="526" class="text-muted" font-size="9">Icono: clipboard-check generico (representa "servicio prestado/completado"). Mismo icono en todas las filas = coherente, no decorativo.</text>
+  <text x="16" y="538" class="text-muted" font-size="9">Columnas fijas: icono x=38 | nombre x=64 | cant x=422 | importe x=536(end) | eliminar x=552. Alineacion vertical perfecta.</text>
+  <text x="16" y="550" class="text-muted" font-size="9">Tokens: fondo --bg, superficie --surface, bordes --border, texto --ink/--ink-3, total Noto Serif 900. Radios --r-sm (7px) y --r-xl (18px).</text>
+</svg>

--- a/design/services-v7-receipt.svg
+++ b/design/services-v7-receipt.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 540" font-family="Roboto, sans-serif">
+  <defs>
+    <style>
+      .bg { fill: #F6F5F1; }
+      .card { fill: #FFFFFF; stroke: #E8E7E2; stroke-width: 1; rx: 18; }
+      .text-section { fill: #9B9893; font-size: 10px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; }
+      .text-label { fill: #6B6760; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; }
+      .text-muted { fill: #9B9893; font-size: 10px; }
+      .text-placeholder { fill: #C4C0BA; font-size: 11px; }
+      .text-value { fill: #2C2925; font-size: 13px; }
+      .text-name { fill: #2C2925; font-size: 13px; font-weight: 500; }
+      .input-bg { fill: #FFFFFF; stroke: #E8E7E2; stroke-width: 1; rx: 7; }
+      .search-bg { fill: #F6F5F1; stroke: #E8E7E2; stroke-width: 1; rx: 7; }
+      .separator { stroke: #E8E7E2; stroke-width: 1; }
+      .separator-light { stroke: #E8E7E2; stroke-width: 0.5; stroke-dasharray: 2 2; }
+      .annotation { fill: #9B9893; font-size: 8px; font-style: italic; }
+      .price { fill: #3A3731; font-size: 13px; font-weight: 500; font-family: 'Noto Serif JP', serif; }
+      .price-detail { fill: #9B9893; font-size: 10px; }
+      .qty { fill: #6B6760; font-size: 11px; }
+      .total-bg { fill: #F6F5F1; stroke: none; rx: 7; }
+      .total-value { fill: #1A1916; font-size: 17px; font-weight: 900; font-family: 'Noto Serif JP', serif; }
+      .total-label { fill: #6B6760; font-size: 12px; font-weight: 700; }
+      .icon-header { fill: none; stroke: #9B9893; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <rect width="620" height="540" class="bg" rx="8"/>
+
+  <!-- ═══ CARD ═══ -->
+  <rect x="16" y="16" width="588" height="350" class="card"/>
+
+  <!-- Header de seccion con icono Receipt -->
+  <g transform="translate(30, 32)">
+    <!-- Icono Receipt (Lucide): rectangulo con lineas internas + zigzag inferior -->
+    <rect x="0" y="0" width="16" height="18" rx="2" class="icon-header"/>
+    <line x1="4" y1="5" x2="12" y2="5" class="icon-header" stroke-width="1.2"/>
+    <line x1="4" y1="9" x2="12" y2="9" class="icon-header" stroke-width="1.2"/>
+    <line x1="4" y1="13" x2="9" y2="13" class="icon-header" stroke-width="1.2"/>
+  </g>
+  <text x="52" y="46" class="text-section">Servicios prestados</text>
+  <line x1="30" y1="56" x2="590" y2="56" class="separator"/>
+
+  <!-- Motivo -->
+  <text x="30" y="74" class="text-label">Motivo *</text>
+  <rect x="30" y="80" width="560" height="28" class="input-bg"/>
+  <text x="42" y="98" class="text-value">Control anual de rutina</text>
+
+  <!-- Buscador -->
+  <rect x="30" y="118" width="560" height="30" class="search-bg"/>
+  <circle cx="48" cy="133" r="6" fill="none" stroke="#C4C0BA" stroke-width="1.2"/>
+  <line x1="52" y1="137" x2="56" y2="141" fill="none" stroke="#C4C0BA" stroke-width="1.2" stroke-linecap="round"/>
+  <text x="64" y="137" class="text-placeholder">Agregar servicio...</text>
+
+  <!--
+    Filas tipo ticket:
+    Nombre (izq) ..... cantidad x precio (der)
+    Alineacion: nombre x=30, qty x=460, precio x=574 (end)
+  -->
+
+  <!-- Fila 1 -->
+  <text x="30" y="174" class="text-name">Consulta general</text>
+  <text x="460" y="174" class="qty">x1</text>
+  <text x="574" y="174" text-anchor="end" class="price">$5,000</text>
+
+  <!-- Separador punteado -->
+  <line x1="30" y1="184" x2="574" y2="184" class="separator-light"/>
+
+  <!-- Fila 2 -->
+  <text x="30" y="204" class="text-name">Vacuna antirrábica</text>
+  <text x="460" y="204" class="qty">x1</text>
+  <text x="574" y="204" text-anchor="end" class="price">$3,500</text>
+
+  <line x1="30" y1="214" x2="574" y2="214" class="separator-light"/>
+
+  <!-- Fila 3 (cantidad > 1) -->
+  <text x="30" y="234" class="text-name">Análisis de sangre completo</text>
+  <text x="460" y="234" class="qty">x2</text>
+  <text x="574" y="234" text-anchor="end" class="price">$7,000</text>
+  <text x="574" y="248" text-anchor="end" class="price-detail">2 x $3,500</text>
+
+  <!-- Ultima fila sin separador (DS seccion 4.2) -->
+
+  <!-- Boton agregar -->
+  <rect x="30" y="264" width="560" height="26" rx="7" fill="#FFFFFF" stroke="#D4D3CC" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="310" y="281" text-anchor="middle" class="text-muted" font-size="10">+ Agregar servicio</text>
+
+  <!-- Total: footer pattern del DS, fondo bg, border-top -->
+  <line x1="30" y1="302" x2="574" y2="302" class="separator"/>
+  <rect x="30" y="308" width="560" height="38" class="total-bg"/>
+  <text x="44" y="332" class="total-label">Total</text>
+  <text x="574" y="333" text-anchor="end" class="total-value">$15,500</text>
+
+  <!-- ═══ showPrices = false ═══ -->
+  <line x1="0" y1="382" x2="620" y2="382" class="separator"/>
+  <text x="16" y="402" class="text-section" style="text-transform: none; font-weight: 600">showPrices = false</text>
+
+  <rect x="16" y="412" width="588" height="116" class="card"/>
+
+  <g transform="translate(30, 428)">
+    <rect x="0" y="0" width="16" height="18" rx="2" class="icon-header"/>
+    <line x1="4" y1="5" x2="12" y2="5" class="icon-header" stroke-width="1.2"/>
+    <line x1="4" y1="9" x2="12" y2="9" class="icon-header" stroke-width="1.2"/>
+    <line x1="4" y1="13" x2="9" y2="13" class="icon-header" stroke-width="1.2"/>
+  </g>
+  <text x="52" y="442" class="text-section">Servicios prestados</text>
+  <line x1="30" y1="452" x2="590" y2="452" class="separator"/>
+
+  <text x="30" y="474" class="text-name">Consulta general</text>
+  <text x="574" y="474" text-anchor="end" class="qty">x1</text>
+
+  <line x1="30" y1="484" x2="574" y2="484" class="separator-light"/>
+
+  <text x="30" y="504" class="text-name">Vacuna antirrábica</text>
+  <text x="574" y="504" text-anchor="end" class="qty">x1</text>
+
+  <text x="30" y="524" class="annotation">Sin precios, sin total. Nombre + cantidad. El icono Receipt en el header da contexto de "registro de servicios".</text>
+</svg>

--- a/drizzle/0002_structured_medication_fields.sql
+++ b/drizzle/0002_structured_medication_fields.sql
@@ -1,0 +1,19 @@
+-- Reemplazar campos de texto libre por columnas estructuradas en medicamentos
+-- dosage → dosage_amount (numeric) + dosage_unit (text)
+-- frequency → frequency_hours (integer)
+-- duration → duration_amount (integer) + duration_unit (text)
+-- Nuevo: route (via de administracion)
+
+ALTER TABLE "module_consultations_consultation_medications"
+  ADD COLUMN IF NOT EXISTS "dosage_amount" numeric,
+  ADD COLUMN IF NOT EXISTS "dosage_unit" text,
+  ADD COLUMN IF NOT EXISTS "route" text,
+  ADD COLUMN IF NOT EXISTS "frequency_hours" integer,
+  ADD COLUMN IF NOT EXISTS "duration_amount" integer,
+  ADD COLUMN IF NOT EXISTS "duration_unit" text;
+--> statement-breakpoint
+
+ALTER TABLE "module_consultations_consultation_medications"
+  DROP COLUMN IF EXISTS "dosage",
+  DROP COLUMN IF EXISTS "frequency",
+  DROP COLUMN IF EXISTS "duration";

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1771385111659,
       "tag": "0001_lyrical_the_twelve",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1774393200000,
+      "tag": "0002_structured_medication_fields",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -16,7 +16,7 @@ import { useConsultationMutations } from '../hooks/useConsultationMutations.js';
 import { useConsultationsSettings } from '../hooks/useConsultationsSettings.js';
 import type { ConsultationFormProps } from '../types/components.js';
 import type { MedicationInput, ServiceLineInput } from '../types/consultation.js';
-import { ALL_REASON_CATEGORIES, REASON_CATEGORY_LABELS } from '../utils/labels.js';
+// ALL_REASON_CATEGORIES y REASON_CATEGORY_LABELS removidos del form (chips eliminados del diseño v3)
 
 import { MedicationFormList } from './MedicationFormList.js';
 import { ServiceLineForm } from './ServiceLineForm.js';
@@ -24,6 +24,15 @@ import { ServiceLineForm } from './ServiceLineForm.js';
 const React = getHostReact();
 const UI = getHostUI();
 const { useState, useCallback, useEffect, useRef, useMemo } = React;
+
+function SectionHeader({ icon, title }: { icon: string; title: string }) {
+  return React.createElement(
+    'h3',
+    { className: 'flex items-center gap-2 text-sm font-medium text-cg-text-muted' },
+    React.createElement(UI.DynamicIcon, { icon, size: 14, className: 'text-cg-text-muted' }),
+    title
+  );
+}
 
 export function ConsultationForm(props: ConsultationFormProps) {
   const { consultationId, petId, defaults, onSuccess, onCancel, className = '' } = props;
@@ -46,13 +55,12 @@ export function ConsultationForm(props: ConsultationFormProps) {
   const [weightKg, setWeightKg] = useState(defaults?.weight_kg ?? '');
   const [temperature, setTemperature] = useState(defaults?.temperature ?? '');
   const [reason, setReason] = useState(defaults?.reason ?? '');
-  const [reasonCategory, setReasonCategory] = useState(defaults?.reason_category ?? '');
+  const [clinicalExamOpen, setClinicalExamOpen] = useState(false);
   const [anamnesis, setAnamnesis] = useState(defaults?.anamnesis ?? '');
   const [physicalExam, setPhysicalExam] = useState(defaults?.physical_exam ?? '');
   const [diagnosis, setDiagnosis] = useState(defaults?.diagnosis ?? '');
   const [treatment, setTreatment] = useState(defaults?.treatment ?? '');
   const [followUpDate, setFollowUpDate] = useState(defaults?.follow_up_date ?? '');
-  const [followUpNotes, setFollowUpNotes] = useState(defaults?.follow_up_notes ?? '');
   const [notes, setNotes] = useState(defaults?.notes ?? '');
   const [medications, setMedications] = useState<MedicationInput[]>(defaults?.medications ?? []);
   const [serviceLines, setServiceLines] = useState<ServiceLineInput[]>(defaults?.services ?? []);
@@ -71,10 +79,6 @@ export function ConsultationForm(props: ConsultationFormProps) {
   }, []);
 
   useEffect(() => {
-    if (!consultSettings.showPrices) {
-      setCatalogLoading(false);
-      return;
-    }
     void (async () => {
       try {
         const cats = await actions.execute<Category[]>('products.categories.listTree');
@@ -103,7 +107,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
         if (catalogMountedRef.current) setCatalogLoading(false);
       }
     })();
-  }, [consultSettings.showPrices]);
+  }, []);
 
   // Subcategorías de servicios para el modal de creación
   const serviceSubcategories = useMemo(() => {
@@ -121,6 +125,24 @@ export function ConsultationForm(props: ConsultationFormProps) {
     onMedicationsChange: setMedications,
   });
 
+  // Precargar peso del paciente al crear consulta nueva
+  useEffect(() => {
+    if (isEditing || weightKg) return;
+    const targetPetId = petId ?? defaults?.pet_id;
+    if (!targetPetId) return;
+    void (async () => {
+      try {
+        const pet = await actions.execute<{ weight_kg: string | null } | undefined>(
+          'patients.pets.getById',
+          { id: targetPetId }
+        );
+        if (pet?.weight_kg) setWeightKg(pet.weight_kg);
+      } catch {
+        // patients plugin puede no estar instalado
+      }
+    })();
+  }, [petId, defaults?.pet_id, isEditing, weightKg]);
+
   // Cargar defaults del settings
   useEffect(() => {
     if (!isEditing && consultSettings.defaultVet && !vetName) {
@@ -136,13 +158,12 @@ export function ConsultationForm(props: ConsultationFormProps) {
       setWeightKg(existing.weight_kg ?? '');
       setTemperature(existing.temperature ?? '');
       setReason(existing.reason);
-      setReasonCategory(existing.reason_category ?? '');
+      if (existing.anamnesis || existing.physical_exam) setClinicalExamOpen(true);
       setAnamnesis(existing.anamnesis ?? '');
       setPhysicalExam(existing.physical_exam ?? '');
       setDiagnosis(existing.diagnosis ?? '');
       setTreatment(existing.treatment ?? '');
       setFollowUpDate(existing.follow_up_date ?? '');
-      setFollowUpNotes(existing.follow_up_notes ?? '');
       setNotes(existing.notes ?? '');
     }
   }, [existing]);
@@ -152,9 +173,12 @@ export function ConsultationForm(props: ConsultationFormProps) {
       setMedications(
         existingMeds.map((m) => ({
           name: m.name,
-          dosage: m.dosage,
-          frequency: m.frequency,
-          duration: m.duration,
+          dosage_amount: m.dosage_amount,
+          dosage_unit: m.dosage_unit,
+          route: m.route,
+          frequency_hours: m.frequency_hours,
+          duration_amount: m.duration_amount,
+          duration_unit: m.duration_unit,
           notes: m.notes,
         }))
       );
@@ -202,13 +226,13 @@ export function ConsultationForm(props: ConsultationFormProps) {
           weight_kg: weightKg || null,
           temperature: temperature || null,
           reason: reason.trim(),
-          reason_category: reasonCategory || null,
+          reason_category: null,
           anamnesis: anamnesis.trim() || null,
           physical_exam: physicalExam.trim() || null,
           diagnosis: diagnosis.trim() || null,
           treatment: treatment.trim() || null,
           follow_up_date: followUpDate || null,
-          follow_up_notes: followUpNotes.trim() || null,
+          follow_up_notes: null,
           notes: notes.trim() || null,
           services: validServices,
         });
@@ -227,13 +251,13 @@ export function ConsultationForm(props: ConsultationFormProps) {
           weight_kg: weightKg || null,
           temperature: temperature || null,
           reason: reason.trim(),
-          reason_category: reasonCategory || null,
+          reason_category: null,
           anamnesis: anamnesis.trim() || null,
           physical_exam: physicalExam.trim() || null,
           diagnosis: diagnosis.trim() || null,
           treatment: treatment.trim() || null,
           follow_up_date: followUpDate || null,
-          follow_up_notes: followUpNotes.trim() || null,
+          follow_up_notes: null,
           notes: notes.trim() || null,
           medications: validMeds,
           services: validServices,
@@ -251,13 +275,11 @@ export function ConsultationForm(props: ConsultationFormProps) {
       weightKg,
       temperature,
       reason,
-      reasonCategory,
       anamnesis,
       physicalExam,
       diagnosis,
       treatment,
       followUpDate,
-      followUpNotes,
       notes,
       medications,
       serviceLines,
@@ -279,11 +301,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
       React.createElement(
         'div',
         { className: 'flex flex-col gap-3' },
-        React.createElement(
-          'h3',
-          { className: 'text-sm font-medium text-cg-text-muted' },
-          'Datos básicos'
-        ),
+        React.createElement(SectionHeader, { icon: 'ClipboardList', title: 'Datos básicos' }),
         React.createElement(
           'div',
           { className: 'grid grid-cols-2 gap-3' },
@@ -345,46 +363,39 @@ export function ConsultationForm(props: ConsultationFormProps) {
       )
     ),
 
-    // Seccion 2: Motivo
+    // Seccion 2: Servicios prestados (siempre visible) + Motivo
     React.createElement(
       UI.Card,
       { className: 'p-4' },
       React.createElement(
         'div',
         { className: 'flex flex-col gap-3' },
+        React.createElement(SectionHeader, { icon: 'Receipt', title: 'Servicios prestados' }),
         React.createElement(
-          'h3',
-          { className: 'text-sm font-medium text-cg-text-muted' },
-          'Motivo de consulta'
+          'div',
+          { className: 'flex flex-col gap-1' },
+          React.createElement(UI.Label, null, 'Motivo *'),
+          React.createElement(UI.Input, {
+            type: 'text',
+            value: reason,
+            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setReason(e.target.value),
+            placeholder: 'Ej: Control anual, vacunación, vómitos...',
+            required: true,
+          })
         ),
-        consultSettings.reasonCategoriesEnabled &&
-          React.createElement(
-            'div',
-            { className: 'flex flex-wrap gap-2' },
-            ALL_REASON_CATEGORIES.map((cat) =>
-              React.createElement(
-                UI.Chip,
-                {
-                  key: cat,
-                  variant: reasonCategory === cat ? 'brand' : 'default',
-                  onClick: () => setReasonCategory(reasonCategory === cat ? '' : cat),
-                  className: 'cursor-pointer',
-                },
-                REASON_CATEGORY_LABELS[cat]
-              )
-            )
-          ),
-        React.createElement(UI.Textarea, {
-          value: reason,
-          onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setReason(e.target.value),
-          placeholder: 'Motivo de la consulta *',
-          rows: 2,
-          required: true,
+        React.createElement(ServiceLineForm, {
+          services: serviceLines,
+          onChange: setServiceLines,
+          catalog: serviceCatalog,
+          categories: serviceSubcategories,
+          catalogLoading,
+          onProductCreated: handleProductCreated,
+          showPrices: consultSettings.showPrices,
         })
       )
     ),
 
-    // Seccion 3: Examen clinico
+    // Seccion 3: Examen clínico (colapsable, cerrado por defecto)
     React.createElement(
       UI.Card,
       { className: 'p-4' },
@@ -392,48 +403,66 @@ export function ConsultationForm(props: ConsultationFormProps) {
         'div',
         { className: 'flex flex-col gap-3' },
         React.createElement(
-          'h3',
-          { className: 'text-sm font-medium text-cg-text-muted' },
-          'Examen clínico'
-        ),
-        React.createElement(
           'div',
-          { className: 'flex flex-col gap-1' },
-          React.createElement(UI.Label, null, 'Anamnesis'),
-          React.createElement(UI.Textarea, {
-            value: anamnesis,
-            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setAnamnesis(e.target.value),
-            placeholder: 'Lo que reporta el dueño...',
-            rows: 2,
-          })
+          {
+            className: 'flex items-center gap-2 cursor-pointer select-none',
+            onClick: () => setClinicalExamOpen(!clinicalExamOpen),
+          },
+          React.createElement(
+            'span',
+            { className: 'text-xs text-cg-text-muted' },
+            clinicalExamOpen ? '\u25BC' : '\u25B6'
+          ),
+          React.createElement(UI.DynamicIcon, {
+            icon: 'Stethoscope',
+            size: 14,
+            className: 'text-cg-text-muted',
+          }),
+          React.createElement(
+            'h3',
+            { className: 'text-sm font-medium text-cg-text-muted' },
+            'Examen clínico'
+          ),
+          !clinicalExamOpen &&
+            (anamnesis || physicalExam) &&
+            React.createElement(UI.Badge, { variant: 'secondary', size: 'sm' }, 'Con datos')
         ),
-        React.createElement(
-          'div',
-          { className: 'flex flex-col gap-1' },
-          React.createElement(UI.Label, null, 'Examen físico'),
-          React.createElement(UI.Textarea, {
-            value: physicalExam,
-            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-              setPhysicalExam(e.target.value),
-            placeholder: 'Hallazgos del examen...',
-            rows: 2,
-          })
-        )
+        clinicalExamOpen &&
+          React.createElement(
+            'div',
+            { className: 'flex flex-col gap-1' },
+            React.createElement(UI.Label, null, 'Anamnesis'),
+            React.createElement(UI.Textarea, {
+              value: anamnesis,
+              onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setAnamnesis(e.target.value),
+              placeholder: 'Lo que reporta el dueño...',
+              rows: 2,
+            })
+          ),
+        clinicalExamOpen &&
+          React.createElement(
+            'div',
+            { className: 'flex flex-col gap-1' },
+            React.createElement(UI.Label, null, 'Examen físico'),
+            React.createElement(UI.Textarea, {
+              value: physicalExam,
+              onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                setPhysicalExam(e.target.value),
+              placeholder: 'Hallazgos del examen...',
+              rows: 2,
+            })
+          )
       )
     ),
 
-    // Seccion 4: Diagnostico
+    // Seccion 4: Diagnóstico
     React.createElement(
       UI.Card,
       { className: 'p-4' },
       React.createElement(
         'div',
         { className: 'flex flex-col gap-3' },
-        React.createElement(
-          'h3',
-          { className: 'text-sm font-medium text-cg-text-muted' },
-          'Diagnóstico'
-        ),
+        React.createElement(SectionHeader, { icon: 'SearchCheck', title: 'Diagnóstico' }),
         React.createElement(UI.Textarea, {
           value: diagnosis,
           onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setDiagnosis(e.target.value),
@@ -443,48 +472,25 @@ export function ConsultationForm(props: ConsultationFormProps) {
       )
     ),
 
-    // Seccion 5: Servicios prestados (condicional)
-    consultSettings.showPrices &&
-      React.createElement(
-        UI.Card,
-        { className: 'p-4' },
-        React.createElement(
-          'div',
-          { className: 'flex flex-col gap-3' },
-          React.createElement(
-            'h3',
-            { className: 'text-sm font-medium text-cg-text-muted' },
-            'Servicios prestados'
-          ),
-          React.createElement(ServiceLineForm, {
-            services: serviceLines,
-            onChange: setServiceLines,
-            catalog: serviceCatalog,
-            categories: serviceSubcategories,
-            catalogLoading,
-            onProductCreated: handleProductCreated,
-          })
-        )
-      ),
-
-    // Seccion 6: Tratamiento + Medicamentos
+    // Seccion 5: Tratamiento + Medicamentos
     React.createElement(
       UI.Card,
       { className: 'p-4' },
       React.createElement(
         'div',
         { className: 'flex flex-col gap-3' },
+        React.createElement(SectionHeader, { icon: 'Pill', title: 'Tratamiento' }),
         React.createElement(
-          'h3',
-          { className: 'text-sm font-medium text-cg-text-muted' },
-          'Tratamiento'
+          'div',
+          { className: 'flex flex-col gap-1' },
+          React.createElement(UI.Label, null, 'Indicaciones generales'),
+          React.createElement(UI.Input, {
+            type: 'text',
+            value: treatment,
+            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setTreatment(e.target.value),
+            placeholder: 'Ej: Dieta blanda, reposo, collar isabelino...',
+          })
         ),
-        React.createElement(UI.Textarea, {
-          value: treatment,
-          onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setTreatment(e.target.value),
-          placeholder: 'Plan de tratamiento...',
-          rows: 2,
-        }),
         React.createElement(UI.Label, null, 'Medicación'),
         // Si hay contribuciones de otros plugins, usarlas; si no, fallback al formulario nativo
         ...(contributedSections.length > 0
@@ -505,18 +511,14 @@ export function ConsultationForm(props: ConsultationFormProps) {
       )
     ),
 
-    // Seccion 7: Seguimiento
+    // Seccion 6: Seguimiento (notas unificadas)
     React.createElement(
       UI.Card,
       { className: 'p-4' },
       React.createElement(
         'div',
         { className: 'flex flex-col gap-3' },
-        React.createElement(
-          'h3',
-          { className: 'text-sm font-medium text-cg-text-muted' },
-          'Seguimiento'
-        ),
+        React.createElement(SectionHeader, { icon: 'CalendarCheck', title: 'Seguimiento' }),
         React.createElement(
           'div',
           { className: 'grid grid-cols-2 gap-3' },
@@ -533,26 +535,14 @@ export function ConsultationForm(props: ConsultationFormProps) {
           React.createElement(
             'div',
             { className: 'flex flex-col gap-1' },
-            React.createElement(UI.Label, null, 'Notas de seguimiento'),
+            React.createElement(UI.Label, null, 'Notas'),
             React.createElement(UI.Input, {
               type: 'text',
-              value: followUpNotes,
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                setFollowUpNotes(e.target.value),
-              placeholder: 'Indicaciones para el próximo control...',
+              value: notes,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) => setNotes(e.target.value),
+              placeholder: 'Observaciones, indicaciones para el próximo control...',
             })
           )
-        ),
-        React.createElement(
-          'div',
-          { className: 'flex flex-col gap-1' },
-          React.createElement(UI.Label, null, 'Notas generales'),
-          React.createElement(UI.Textarea, {
-            value: notes,
-            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setNotes(e.target.value),
-            placeholder: 'Observaciones adicionales...',
-            rows: 2,
-          })
         )
       )
     ),

--- a/src/components/MedicationFormList.tsx
+++ b/src/components/MedicationFormList.tsx
@@ -1,47 +1,78 @@
 /**
- * Lista editable de medicamentos para el formulario de consulta.
+ * Lista editable de medicamentos con campos estructurados y collapse/expand.
  */
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
+import { DOSAGE_UNITS, ROUTES, FREQUENCY_HOURS, DURATION_UNITS } from '../constants/medication.js';
 import type { MedicationFormListProps } from '../types/components.js';
 import type { MedicationInput } from '../types/consultation.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useCallback } = React;
+const { useState, useCallback } = React;
 
 const EMPTY_MEDICATION: MedicationInput = {
   name: '',
-  dosage: null,
-  frequency: null,
-  duration: null,
+  dosage_amount: null,
+  dosage_unit: 'mg/kg',
+  route: 'Oral',
+  frequency_hours: null,
+  duration_amount: null,
+  duration_unit: 'días',
   notes: null,
 };
+
+function formatSummary(med: MedicationInput): string {
+  const parts: string[] = [];
+  if (med.dosage_amount && med.dosage_unit) parts.push(`${med.dosage_amount} ${med.dosage_unit}`);
+  if (med.route) parts.push(med.route);
+  if (med.frequency_hours) parts.push(`c/${String(med.frequency_hours)}h`);
+  if (med.duration_amount && med.duration_unit)
+    parts.push(`${String(med.duration_amount)} ${med.duration_unit}`);
+  return parts.join(' · ');
+}
+
+function isMedicationComplete(med: MedicationInput): boolean {
+  return !!(med.name.trim() && med.dosage_amount && med.frequency_hours && med.duration_amount);
+}
 
 export function MedicationFormList({
   medications,
   onChange,
   className = '',
 }: MedicationFormListProps) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
   const add = useCallback(() => {
+    const newIndex = medications.length;
     onChange([...medications, { ...EMPTY_MEDICATION }]);
+    setExpandedIndex(newIndex);
   }, [medications, onChange]);
 
   const remove = useCallback(
     (index: number) => {
       onChange(medications.filter((_: MedicationInput, i: number) => i !== index));
+      if (expandedIndex === index) setExpandedIndex(null);
+      else if (expandedIndex !== null && expandedIndex > index) setExpandedIndex(expandedIndex - 1);
     },
-    [medications, onChange]
+    [medications, onChange, expandedIndex]
   );
 
   const updateField = useCallback(
-    (index: number, field: keyof MedicationInput, value: string) => {
+    (index: number, field: keyof MedicationInput, value: string | number | null) => {
       const updated = medications.map((med: MedicationInput, i: number) =>
-        i === index ? { ...med, [field]: value || null } : med
+        i === index ? { ...med, [field]: value === '' ? null : value } : med
       );
       onChange(updated);
     },
     [medications, onChange]
+  );
+
+  const toggleExpand = useCallback(
+    (index: number) => {
+      setExpandedIndex(expandedIndex === index ? null : index);
+    },
+    [expandedIndex]
   );
 
   return React.createElement(
@@ -51,73 +82,310 @@ export function MedicationFormList({
       'div',
       { className: `flex flex-col gap-2 ${className}` },
 
-      medications.map((med: MedicationInput, index: number) =>
-        React.createElement(
-          'div',
-          {
-            key: index,
-            className:
-              'grid grid-cols-[1fr_auto_auto_auto_auto] gap-2 items-start p-2 rounded-lg border border-[var(--cg-border)] bg-[var(--cg-bg-secondary)]',
-          },
+      medications.map((med: MedicationInput, index: number) => {
+        const isExpanded = expandedIndex === index;
+        const hasName = med.name.trim().length > 0;
+        const complete = isMedicationComplete(med);
+        const summary = formatSummary(med);
 
-          // Nombre (requerido)
-          React.createElement(UI.Input, {
-            type: 'text',
-            placeholder: 'Medicamento *',
-            value: med.name,
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-              updateField(index, 'name', e.target.value),
-            size: 'sm',
-          }),
-
-          // Dosis
-          React.createElement(UI.Input, {
-            type: 'text',
-            placeholder: 'Ej: 2ml, 1 comp.',
-            value: med.dosage ?? '',
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-              updateField(index, 'dosage', e.target.value),
-            className: 'w-24',
-            size: 'sm',
-          }),
-
-          // Frecuencia
-          React.createElement(UI.Input, {
-            type: 'text',
-            placeholder: 'Ej: cada 8hs',
-            value: med.frequency ?? '',
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-              updateField(index, 'frequency', e.target.value),
-            className: 'w-28',
-            size: 'sm',
-          }),
-
-          // Duración
-          React.createElement(UI.Input, {
-            type: 'text',
-            placeholder: 'Ej: 7 días',
-            value: med.duration ?? '',
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-              updateField(index, 'duration', e.target.value),
-            className: 'w-24',
-            size: 'sm',
-          }),
-
-          // Botón eliminar
-          React.createElement(UI.Tooltip, {
-            content: 'Eliminar medicamento',
-            children: React.createElement(
+        // Fila colapsada
+        if (!isExpanded) {
+          return React.createElement(
+            'div',
+            {
+              key: index,
+              className: `flex items-center gap-2 p-2 rounded-lg border cursor-pointer ${
+                complete
+                  ? 'border-[var(--cg-border)] bg-[var(--cg-bg-secondary)]'
+                  : 'border-dashed border-[var(--cg-border)] bg-[var(--cg-bg-secondary)]'
+              }`,
+              onClick: () => toggleExpand(index),
+            },
+            // Chevron
+            React.createElement(
+              'span',
+              { className: 'text-[var(--cg-text-muted)] text-xs shrink-0' },
+              '\u25B6'
+            ),
+            // Pill del nombre
+            hasName
+              ? React.createElement(
+                  'span',
+                  {
+                    className: `px-2.5 py-0.5 rounded-full text-xs font-medium shrink-0 ${
+                      complete
+                        ? 'bg-[var(--cg-bg)] text-[var(--cg-text)]'
+                        : 'bg-[var(--cg-warning-bg)] text-[var(--cg-warning-text)]'
+                    }`,
+                  },
+                  med.name
+                )
+              : React.createElement(
+                  'span',
+                  { className: 'text-xs text-[var(--cg-text-muted)] italic' },
+                  'Sin nombre'
+                ),
+            // Resumen
+            summary &&
+              React.createElement(
+                'span',
+                { className: 'text-xs text-[var(--cg-text-muted)] truncate min-w-0' },
+                summary
+              ),
+            // Badge incompleto
+            !complete &&
+              hasName &&
+              React.createElement(UI.Badge, { variant: 'warning-soft', size: 'sm' }, 'Incompleto'),
+            // Spacer
+            React.createElement('span', { className: 'flex-1' }),
+            // Eliminar
+            React.createElement(
               UI.IconButton,
               {
                 variant: 'danger',
                 size: 'xs',
-                onClick: () => remove(index),
+                onClick: (e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  remove(index);
+                },
               },
-              React.createElement(UI.DynamicIcon, { icon: 'X', size: 16 })
+              React.createElement(UI.DynamicIcon, { icon: 'X', size: 14 })
+            )
+          );
+        }
+
+        // Card expandida
+        return React.createElement(
+          'div',
+          {
+            key: index,
+            className:
+              'flex flex-col gap-3 p-3 rounded-lg border-[1.5px] border-[var(--cg-border)] bg-[var(--cg-surface)]',
+          },
+
+          // Header expandido
+          React.createElement(
+            'div',
+            {
+              className: 'flex items-center gap-2 cursor-pointer',
+              onClick: () => toggleExpand(index),
+            },
+            React.createElement(
+              'span',
+              { className: 'text-[var(--cg-text-muted)] text-xs' },
+              '\u25BC'
             ),
-          })
-        )
-      ),
+            hasName &&
+              React.createElement(
+                'span',
+                {
+                  className:
+                    'px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--cg-bg)] text-[var(--cg-text)]',
+                },
+                med.name
+              ),
+            React.createElement('span', { className: 'flex-1' }),
+            React.createElement(
+              UI.IconButton,
+              {
+                variant: 'danger',
+                size: 'xs',
+                onClick: (e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  remove(index);
+                },
+              },
+              React.createElement(UI.DynamicIcon, { icon: 'X', size: 14 })
+            )
+          ),
+
+          // Separador
+          React.createElement('div', {
+            className: 'border-t border-[var(--cg-border)]',
+          }),
+
+          // Nombre
+          React.createElement(
+            'div',
+            { className: 'flex flex-col gap-1' },
+            React.createElement(UI.Label, null, 'Medicamento *'),
+            React.createElement(UI.Input, {
+              type: 'text',
+              placeholder: 'Ej: Amoxicilina, Meloxicam...',
+              value: med.name,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                updateField(index, 'name', e.target.value),
+              size: 'sm',
+              autoFocus: !hasName,
+            })
+          ),
+
+          // Fila 1: Dosis + Via + Duracion
+          React.createElement(
+            'div',
+            { className: 'grid grid-cols-2 sm:grid-cols-3 gap-2' },
+
+            // Dosis (compound: numero + select)
+            React.createElement(
+              'div',
+              { className: 'flex flex-col gap-1' },
+              React.createElement(UI.Label, null, 'Dosis *'),
+              React.createElement(
+                'div',
+                { className: 'flex gap-1' },
+                React.createElement(UI.Input, {
+                  type: 'number',
+                  step: '0.01',
+                  min: '0',
+                  placeholder: '0',
+                  value: med.dosage_amount ?? '',
+                  onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                    updateField(index, 'dosage_amount', e.target.value),
+                  size: 'sm',
+                  className: 'w-20',
+                }),
+                React.createElement(
+                  UI.Select,
+                  {
+                    value: med.dosage_unit ?? 'mg/kg',
+                    onValueChange: (v: string) => updateField(index, 'dosage_unit', v),
+                  },
+                  DOSAGE_UNITS.map((unit) =>
+                    React.createElement(UI.SelectItem, { key: unit, value: unit }, unit)
+                  )
+                )
+              )
+            ),
+
+            // Via
+            React.createElement(
+              'div',
+              { className: 'flex flex-col gap-1' },
+              React.createElement(UI.Label, null, 'Vía'),
+              React.createElement(
+                UI.Select,
+                {
+                  value: med.route ?? 'Oral',
+                  onValueChange: (v: string) => updateField(index, 'route', v),
+                },
+                ROUTES.map((route) =>
+                  React.createElement(UI.SelectItem, { key: route, value: route }, route)
+                )
+              )
+            ),
+
+            // Duracion (compound: numero + select)
+            React.createElement(
+              'div',
+              { className: 'flex flex-col gap-1' },
+              React.createElement(UI.Label, null, 'Duración *'),
+              React.createElement(
+                'div',
+                { className: 'flex gap-1' },
+                React.createElement(UI.Input, {
+                  type: 'number',
+                  step: '1',
+                  min: '1',
+                  placeholder: '0',
+                  value: med.duration_amount !== null ? String(med.duration_amount) : '',
+                  onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                    updateField(
+                      index,
+                      'duration_amount',
+                      e.target.value ? Number(e.target.value) : null
+                    ),
+                  size: 'sm',
+                  className: 'w-16',
+                }),
+                React.createElement(
+                  UI.Select,
+                  {
+                    value: med.duration_unit ?? 'días',
+                    onValueChange: (v: string) => updateField(index, 'duration_unit', v),
+                  },
+                  DURATION_UNITS.map((unit) =>
+                    React.createElement(UI.SelectItem, { key: unit, value: unit }, unit)
+                  )
+                )
+              )
+            )
+          ),
+
+          // Fila 2: Frecuencia (input + chips presets)
+          React.createElement(
+            'div',
+            { className: 'flex flex-col gap-1' },
+            React.createElement(UI.Label, null, 'Frecuencia *'),
+            React.createElement(
+              'div',
+              { className: 'flex flex-wrap items-center gap-1.5' },
+              React.createElement(
+                'div',
+                { className: 'flex items-center gap-1' },
+                React.createElement(UI.Input, {
+                  type: 'number',
+                  step: '1',
+                  min: '1',
+                  placeholder: 'Cada...',
+                  value: med.frequency_hours !== null ? String(med.frequency_hours) : '',
+                  onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                    updateField(
+                      index,
+                      'frequency_hours',
+                      e.target.value ? Number(e.target.value) : null
+                    ),
+                  size: 'sm',
+                  className: 'w-20',
+                }),
+                React.createElement(
+                  'span',
+                  { className: 'text-xs text-[var(--cg-text-muted)]' },
+                  'hs'
+                )
+              ),
+              ...FREQUENCY_HOURS.map((h) =>
+                React.createElement(
+                  UI.Chip,
+                  {
+                    key: String(h),
+                    variant: med.frequency_hours === h ? 'brand' : 'default',
+                    onClick: () => updateField(index, 'frequency_hours', h),
+                    className: 'cursor-pointer',
+                    size: 'sm',
+                  },
+                  `${String(h)}h`
+                )
+              )
+            )
+          ),
+
+          // Notas
+          React.createElement(
+            'div',
+            { className: 'flex flex-col gap-1' },
+            React.createElement(UI.Label, null, 'Notas'),
+            React.createElement(UI.Input, {
+              type: 'text',
+              placeholder: 'Indicaciones para este medicamento...',
+              value: med.notes ?? '',
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                updateField(index, 'notes', e.target.value),
+              size: 'sm',
+            })
+          ),
+
+          // Preview de resumen
+          summary &&
+            React.createElement(
+              'div',
+              {
+                className:
+                  'text-xs text-[var(--cg-text-muted)] bg-[var(--cg-bg)] rounded px-2 py-1',
+              },
+              `Vista colapsada: ${med.name || '...'} · ${summary}`
+            )
+        );
+      }),
 
       // Botón agregar
       React.createElement(

--- a/src/components/MedicationList.tsx
+++ b/src/components/MedicationList.tsx
@@ -1,13 +1,30 @@
 /**
  * Lista de medicamentos de una consulta (solo lectura).
- * Cada medicamento se muestra como una mini-card con sus detalles.
+ * Muestra campos estructurados como badges formateados.
  */
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
+import { FREQUENCY_LABELS } from '../constants/medication.js';
 import type { MedicationListProps } from '../types/components.js';
+import type { ConsultationMedication } from '../types/consultation.js';
 
 const React = getHostReact();
 const UI = getHostUI();
+
+function formatDosage(med: ConsultationMedication): string | null {
+  if (!med.dosage_amount || !med.dosage_unit) return null;
+  return `${med.dosage_amount} ${med.dosage_unit}`;
+}
+
+function formatFrequency(med: ConsultationMedication): string | null {
+  if (!med.frequency_hours) return null;
+  return FREQUENCY_LABELS[med.frequency_hours] ?? `Cada ${String(med.frequency_hours)}h`;
+}
+
+function formatDuration(med: ConsultationMedication): string | null {
+  if (!med.duration_amount || !med.duration_unit) return null;
+  return `${String(med.duration_amount)} ${med.duration_unit}`;
+}
 
 export function MedicationList(props: MedicationListProps) {
   const { medications, className = '' } = props;
@@ -21,8 +38,13 @@ export function MedicationList(props: MedicationListProps) {
   return React.createElement(
     'div',
     { className: `flex flex-col gap-3 ${className}` },
-    medications.map((med) =>
-      React.createElement(
+    medications.map((med) => {
+      const dosage = formatDosage(med);
+      const frequency = formatFrequency(med);
+      const duration = formatDuration(med);
+      const hasDetails = dosage || med.route || frequency || duration;
+
+      return React.createElement(
         UI.Card,
         { key: med.id, className: 'p-3' },
         // Nombre del medicamento
@@ -40,29 +62,18 @@ export function MedicationList(props: MedicationListProps) {
             med.name
           )
         ),
-        // Detalles como chips
-        (med.dosage || med.frequency || med.duration) &&
+        // Detalles como badges
+        hasDetails &&
           React.createElement(
             'div',
             { className: 'flex flex-wrap gap-1.5 pl-[22px] mt-2' },
-            med.dosage &&
-              React.createElement(
-                UI.Badge,
-                { variant: 'secondary', size: 'sm' },
-                `Dosis: ${med.dosage}`
-              ),
-            med.frequency &&
-              React.createElement(
-                UI.Badge,
-                { variant: 'secondary', size: 'sm' },
-                `Frecuencia: ${med.frequency}`
-              ),
-            med.duration &&
-              React.createElement(
-                UI.Badge,
-                { variant: 'secondary', size: 'sm' },
-                `Duración: ${med.duration}`
-              )
+            dosage && React.createElement(UI.Badge, { variant: 'secondary', size: 'sm' }, dosage),
+            med.route &&
+              React.createElement(UI.Badge, { variant: 'secondary', size: 'sm' }, med.route),
+            frequency &&
+              React.createElement(UI.Badge, { variant: 'secondary', size: 'sm' }, frequency),
+            duration &&
+              React.createElement(UI.Badge, { variant: 'secondary', size: 'sm' }, duration)
           ),
         // Notas
         med.notes &&
@@ -71,7 +82,7 @@ export function MedicationList(props: MedicationListProps) {
             { className: 'text-xs text-[var(--cg-text-muted)] italic pl-[22px] mt-1' },
             med.notes
           )
-      )
-    )
+      );
+    })
   );
 }

--- a/src/components/ServiceLineForm.tsx
+++ b/src/components/ServiceLineForm.tsx
@@ -1,9 +1,8 @@
 /**
  * Componente para gestionar líneas de servicios prestados en una consulta.
  *
- * Usa el Combobox de ui-components para buscar en el catálogo de servicios.
- * Si el texto no existe, "Crear '...'" abre un ServiceFormDialog para crear
- * el servicio y agregarlo a la línea de la consulta.
+ * Diseño tipo ticket/recibo: nombre izquierda, cantidad centro, precio derecha.
+ * showPrices controla visibilidad de precios y total, no de la sección completa.
  */
 import { getHostReact, getHostUI, actions } from '@coongro/plugin-sdk';
 import type { Product, Category } from '@coongro/products';
@@ -32,26 +31,25 @@ function buildServiceLine(product: Product): ServiceLineInput {
 export interface ServiceLineFormProps {
   services: ServiceLineInput[];
   onChange: (services: ServiceLineInput[]) => void;
-  /** Catálogo de productos/servicios disponibles */
   catalog: Product[];
-  /** Categorías para el modal de creación de servicio */
   categories: Category[];
-  /** Indica si el catálogo está cargando */
   catalogLoading?: boolean;
-  /** Callback cuando se crea un producto nuevo (para que el caller actualice su catálogo) */
   onProductCreated?: (product: Product) => void;
+  showPrices?: boolean;
 }
 
 interface ServiceSearchContentProps {
   catalog: Product[];
   categoryMap: Map<string, string>;
   onCreateRequest: (name: string) => void;
+  showPrices: boolean;
 }
 
 function ServiceSearchContent({
   catalog,
   categoryMap,
   onCreateRequest,
+  showPrices,
 }: ServiceSearchContentProps) {
   const { search, setOpen } = UI.useComboboxContext();
 
@@ -82,7 +80,6 @@ function ServiceSearchContent({
   return React.createElement(
     UI.ComboboxContent,
     null,
-
     filtered.length > 0
       ? filtered.map((p: Product) =>
           React.createElement(
@@ -92,7 +89,7 @@ function ServiceSearchContent({
               value: p.id,
               subtitle: [
                 categoryMap.get(p.category_id ?? '') ?? '',
-                formatPrice(p.sale_price, 'Sin precio'),
+                showPrices ? formatPrice(p.sale_price, 'Sin precio') : '',
               ]
                 .filter(Boolean)
                 .join(' · '),
@@ -105,7 +102,6 @@ function ServiceSearchContent({
           null,
           search.trim() ? 'Sin resultados' : 'Escribe para buscar en el catálogo'
         ),
-
     !queryExistsInCatalog &&
       React.createElement(UI.ComboboxCreate, {
         onCreate: handleCreate,
@@ -121,6 +117,7 @@ export function ServiceLineForm({
   categories,
   catalogLoading = false,
   onProductCreated,
+  showPrices = true,
 }: ServiceLineFormProps) {
   const [createName, setCreateName] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -155,7 +152,7 @@ export function ServiceLineForm({
           return true;
         }
       } catch {
-        // El ServiceFormDialog no muestra toast; lo manejamos silenciosamente
+        // Silencioso
       } finally {
         setSaving(false);
       }
@@ -171,16 +168,14 @@ export function ServiceLineForm({
     [services, onChange]
   );
 
-  const handleChange = useCallback(
-    (index: number, field: keyof ServiceLineInput, value: string) => {
+  const handleQuantityChange = useCallback(
+    (index: number, value: string) => {
       const updated = services.map((svc: ServiceLineInput, i: number) => {
         if (i !== index) return svc;
-        const next = { ...svc, [field]: value };
-        if (field === 'quantity' || field === 'unit_price') {
-          const qty = parseFloat(next.quantity) || 0;
-          const price = parseFloat(next.unit_price) || 0;
-          next.subtotal = (qty * price).toFixed(2);
-        }
+        const next = { ...svc, quantity: value };
+        const qty = parseFloat(value) || 0;
+        const price = parseFloat(next.unit_price) || 0;
+        next.subtotal = (qty * price).toFixed(2);
         return next;
       });
       onChange(updated);
@@ -199,9 +194,9 @@ export function ServiceLineForm({
     null,
     React.createElement(
       'div',
-      { className: 'flex flex-col gap-4' },
+      { className: 'flex flex-col gap-3' },
 
-      // Modal de creación via ServiceFormDialog reutilizable
+      // Modal de creación
       React.createElement(ServiceFormDialog, {
         open: createName !== null,
         onClose: () => setCreateName(null),
@@ -212,7 +207,7 @@ export function ServiceLineForm({
         showDescription: false,
       }),
 
-      // Combobox buscador
+      // Buscador
       React.createElement(
         UI.Combobox,
         {
@@ -221,122 +216,121 @@ export function ServiceLineForm({
           debounceMs: 0,
         },
         React.createElement(UI.ComboboxChipTrigger, {
-          placeholder: catalogLoading ? 'Cargando catálogo...' : 'Buscar servicio para agregar...',
+          placeholder: catalogLoading ? 'Cargando catálogo...' : 'Agregar servicio...',
         }),
         React.createElement(ServiceSearchContent, {
           catalog,
           categoryMap,
           onCreateRequest: (name: string) => setCreateName(name),
+          showPrices,
         })
       ),
 
-      // Líneas de servicios
+      // Filas tipo ticket
       services.length > 0 &&
         React.createElement(
           'div',
-          {
-            className: 'rounded-md border border-cg-border overflow-hidden',
-          },
+          { className: 'flex flex-col' },
 
-          // Encabezados
-          React.createElement(
-            'div',
-            {
-              className:
-                'grid grid-cols-[1fr_70px_90px_90px_32px] gap-2 items-center px-3 py-2 bg-cg-surface-raised text-xs font-medium text-cg-text-muted border-b border-cg-border',
-            },
-            React.createElement('span', null, 'Servicio'),
-            React.createElement('span', { className: 'text-center' }, 'Cant.'),
-            React.createElement('span', { className: 'text-right' }, 'Precio unit.'),
-            React.createElement('span', { className: 'text-right' }, 'Subtotal'),
-            React.createElement('span', null, '')
-          ),
+          services.map((svc: ServiceLineInput, index: number) => {
+            const qty = parseFloat(svc.quantity) || 0;
+            const unitPrice = parseFloat(svc.unit_price) || 0;
+            const hasMultiple = qty > 1;
+            const isLast = index === services.length - 1;
 
-          // Filas
-          React.createElement(
-            'div',
-            { className: 'divide-y divide-cg-border' },
-            services.map((svc: ServiceLineInput, index: number) =>
-              React.createElement(
-                'div',
-                {
-                  key: index,
-                  className:
-                    'grid grid-cols-[1fr_70px_90px_90px_32px] gap-2 items-center px-3 py-2',
+            return React.createElement(
+              'div',
+              {
+                key: index,
+                className: `grid items-center py-2.5 gap-2 min-w-0 ${
+                  !isLast ? 'border-b border-dashed border-[var(--cg-border)]' : ''
+                }`,
+                style: {
+                  gridTemplateColumns: showPrices ? '1fr 48px 80px 24px' : '1fr 48px 24px',
                 },
+              },
 
-                React.createElement(UI.Input, {
-                  type: 'text',
-                  value: svc.product_name,
-                  onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                    handleChange(index, 'product_name', e.target.value),
-                  placeholder: 'Nombre del servicio',
-                  readOnly: !!svc.product_id,
-                  size: 'sm',
-                }),
+              // Nombre
+              React.createElement(
+                'span',
+                {
+                  className:
+                    'flex-1 text-[13px] font-medium text-[var(--cg-text)] min-w-0 truncate',
+                },
+                svc.product_name
+              ),
 
-                React.createElement(UI.Input, {
-                  type: 'number',
-                  value: svc.quantity,
-                  onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                    handleChange(index, 'quantity', e.target.value),
-                  min: '1',
-                  step: '1',
-                  className: 'text-center',
-                  size: 'sm',
-                }),
+              // Cantidad (input editable)
+              React.createElement(UI.Input, {
+                type: 'number',
+                value: svc.quantity,
+                onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                  handleQuantityChange(index, e.target.value),
+                min: '1',
+                step: '1',
+                size: 'sm',
+                className: '!w-[48px] text-center',
+              }),
 
-                React.createElement(UI.Input, {
-                  type: 'number',
-                  value: svc.unit_price,
-                  onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                    handleChange(index, 'unit_price', e.target.value),
-                  min: '0',
-                  step: '0.01',
-                  className: 'text-right',
-                  size: 'sm',
-                }),
-
+              // Precio (Noto Serif, solo si showPrices)
+              showPrices &&
                 React.createElement(
-                  'span',
-                  { className: 'text-sm text-right font-medium text-cg-text' },
-                  formatCurrency(parseFloat(svc.subtotal) || 0)
+                  'div',
+                  { className: 'flex flex-col items-end' },
+                  React.createElement(
+                    'span',
+                    {
+                      className: 'text-[13px] font-medium text-[var(--cg-text-secondary)]',
+                      style: { fontFamily: "'Noto Serif JP', serif" },
+                    },
+                    formatCurrency(parseFloat(svc.subtotal) || 0)
+                  ),
+                  hasMultiple &&
+                    React.createElement(
+                      'span',
+                      { className: 'text-[10px] text-[var(--cg-text-muted)]' },
+                      `${String(qty)} x ${formatCurrency(unitPrice)}`
+                    )
                 ),
 
-                React.createElement(UI.Tooltip, {
-                  content: 'Eliminar',
-                  children: React.createElement(
-                    UI.IconButton,
-                    {
-                      variant: 'danger',
-                      size: 'xs',
-                      onClick: () => handleRemove(index),
-                    },
-                    React.createElement(UI.DynamicIcon, { icon: 'X', size: 16 })
-                  ),
-                })
+              // Eliminar
+              React.createElement(
+                UI.IconButton,
+                {
+                  variant: 'danger',
+                  size: 'xs',
+                  onClick: () => handleRemove(index),
+                },
+                React.createElement(UI.DynamicIcon, { icon: 'X', size: 14 })
               )
-            )
-          ),
+            );
+          }),
 
           // Total
-          React.createElement(
-            'div',
-            {
-              className:
-                'flex items-center justify-end gap-3 px-3 py-2.5 border-t border-cg-border bg-cg-surface-raised',
-            },
+          showPrices &&
             React.createElement(
-              'span',
-              { className: 'text-sm font-medium text-cg-text-muted' },
-              'Total:'
-            ),
-            React.createElement(
-              'span',
-              { className: 'text-base font-bold text-cg-text' },
-              formatCurrency(total)
+              'div',
+              {
+                className:
+                  'flex items-center justify-between mt-2 pt-2.5 border-t border-[var(--cg-border)]',
+              },
+              React.createElement(
+                'span',
+                {
+                  className:
+                    'text-xs font-bold text-[var(--cg-text-muted)] uppercase tracking-wide',
+                },
+                'Total'
+              ),
+              React.createElement(
+                'span',
+                {
+                  className: 'text-[17px] font-black text-[var(--cg-text)]',
+                  style: { fontFamily: "'Noto Serif JP', serif" },
+                },
+                formatCurrency(total)
+              )
             )
-          )
         )
     )
   );

--- a/src/constants/medication.ts
+++ b/src/constants/medication.ts
@@ -1,0 +1,25 @@
+/**
+ * Constantes de medicacion estructurada.
+ * Exportables para uso cross-plugin (vet-pharmacy puede importarlas).
+ */
+
+export const DOSAGE_UNITS = ['mg/kg', 'mg', 'ml', 'UI/kg', 'gotas', 'comp.'] as const;
+export type DosageUnit = (typeof DOSAGE_UNITS)[number];
+
+export const ROUTES = ['Oral', 'IM', 'IV', 'SC', 'Tópica', 'Oftálmica', 'Ótica'] as const;
+export type Route = (typeof ROUTES)[number];
+
+export const FREQUENCY_HOURS = [6, 8, 12, 24, 48, 72] as const;
+export type FrequencyHours = (typeof FREQUENCY_HOURS)[number];
+
+export const FREQUENCY_LABELS: Record<number, string> = {
+  6: 'Cada 6 horas',
+  8: 'Cada 8 horas',
+  12: 'Cada 12 horas',
+  24: 'Cada 24 horas',
+  48: 'Cada 48 horas',
+  72: 'Cada 72 horas',
+};
+
+export const DURATION_UNITS = ['días', 'semanas', 'meses'] as const;
+export type DurationUnit = (typeof DURATION_UNITS)[number];

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,16 @@ export type {
 } from './types/components.js';
 export type { ServiceLineFormProps } from './components/ServiceLineForm.js';
 
+// Constantes de medicacion (exportables cross-plugin)
+export {
+  DOSAGE_UNITS,
+  ROUTES,
+  FREQUENCY_HOURS,
+  FREQUENCY_LABELS,
+  DURATION_UNITS,
+} from './constants/medication.js';
+export type { DosageUnit, Route, FrequencyHours, DurationUnit } from './constants/medication.js';
+
 // Utilidades
 export { formatPrice, formatCurrency, sanitizePrice, isValidPrice } from './utils/price.js';
 export { createCategoryMap } from './utils/categories.js';

--- a/src/schema/consultation-medication.ts
+++ b/src/schema/consultation-medication.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { integer, numeric, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 
 export const consultationMedicationTable = pgTable(
   'module_consultations_consultation_medications',
@@ -7,9 +7,12 @@ export const consultationMedicationTable = pgTable(
     id: uuid('id').primaryKey().notNull(),
     consultation_id: text('consultation_id').notNull(),
     name: text('name').notNull(),
-    dosage: text('dosage'),
-    frequency: text('frequency'),
-    duration: text('duration'),
+    dosage_amount: numeric('dosage_amount'),
+    dosage_unit: text('dosage_unit'),
+    route: text('route'),
+    frequency_hours: integer('frequency_hours'),
+    duration_amount: integer('duration_amount'),
+    duration_unit: text('duration_unit'),
     notes: text('notes'),
     created_at: timestamp('created_at', { mode: 'string' })
       .notNull()

--- a/src/types/consultation.ts
+++ b/src/types/consultation.ts
@@ -32,9 +32,12 @@ export interface ConsultationMedication {
   id: string;
   consultation_id: string;
   name: string;
-  dosage: string | null;
-  frequency: string | null;
-  duration: string | null;
+  dosage_amount: string | null;
+  dosage_unit: string | null;
+  route: string | null;
+  frequency_hours: number | null;
+  duration_amount: number | null;
+  duration_unit: string | null;
   notes: string | null;
   created_at: string;
 }
@@ -79,9 +82,12 @@ export interface ConsultationUpdateData {
 
 export interface MedicationInput {
   name: string;
-  dosage?: string | null;
-  frequency?: string | null;
-  duration?: string | null;
+  dosage_amount?: string | null;
+  dosage_unit?: string | null;
+  route?: string | null;
+  frequency_hours?: number | null;
+  duration_amount?: number | null;
+  duration_unit?: string | null;
   notes?: string | null;
 }
 


### PR DESCRIPTION
Closes #34

## Changes

### Medication fields (issue #34 core)
- Migration: replace `dosage`, `frequency`, `duration` (text) with structured columns: `dosage_amount` (numeric), `dosage_unit` (text), `route` (text), `frequency_hours` (integer), `duration_amount` (integer), `duration_unit` (text)
- Shared constants exported cross-plugin: `DOSAGE_UNITS`, `ROUTES`, `FREQUENCY_HOURS`, `DURATION_UNITS`
- MedicationFormList: collapse/expand hybrid with structured fields (compound inputs for dose/duration, chips for frequency, select for route)
- MedicationList: read-only display with formatted badges

### Consultation form redesign
- Services section always visible (showPrices only controls price columns, not section visibility)
- Reason category chips removed (redundant with services)
- Motivo changed from textarea to single-line input
- Clinical exam section collapsible (closed by default, opens automatically when editing with data)
- Treatment renamed to "Indicaciones generales" (non-pharmacological)
- follow_up_notes merged into notes (single field)
- Weight auto-prefilled from patient's last record via `patients.pets.getById`
- Section icons added (ClipboardList, Receipt, Stethoscope, SearchCheck, Pill, CalendarCheck)
- ServiceLineForm redesigned: receipt-style rows with grid layout

### Design artifacts
- `design/` folder with SVG wireframes documenting all design iterations (v1-v7)

## Testing
- Create a new consultation and verify structured medication fields work (add, edit quantity/dose, collapse/expand)
- Verify services section shows with and without showPrices
- Verify clinical exam section collapses/expands
- Verify weight auto-fills from patient record
- Verify section icons render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)