### PR TITLE
feat: Consultation form improvements — SOAP, vital signs, structured exam

### DIFF
--- a/.changeset/consultation-form-improvements.md
+++ b/.changeset/consultation-form-improvements.md
@@ -1,0 +1,16 @@
+---
+"@coongro/consultations": minor
+---
+
+Improve consultation form with SOAP workflow, vital signs, and structured physical exam
+
+- Add PetPicker to consultation form when no patient is pre-selected
+- Add heart rate (FC), respiratory rate (FR), and body condition score (BCS) to vital signs
+- Add structured physical exam by body systems (WNL/ABN checklist)
+- Reorder form sections to follow clinical SOAP flow
+- Auto-fill vital signs from patient's last consultation (configurable)
+- Add contextual placeholder examples per body system
+- Add `prefillVitals` and `structuredExam` settings
+- Export medication constants via `./constants/medication` subpath
+- New reusable components: VitalSignCard, PhysicalExamSummary, ExamSystemRow, ExamSystemList
+- Responsive ExamSystemList with compact mode for mobile

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -147,6 +147,20 @@
                 "signos",
                 "vitales"
               ]
+            },
+            {
+              "key": "consultations.structuredExam",
+              "type": "boolean",
+              "label": "Examen físico estructurado",
+              "description": "Mostrar checklist por sistemas (WNL/ABN) en vez de texto libre para el examen físico",
+              "default": true,
+              "tags": [
+                "consultations",
+                "structuredexam",
+                "examen",
+                "físico",
+                "sistemas"
+              ]
             }
           ]
         }

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -80,22 +80,6 @@
       }
     ],
     "settings": {
-      "groups": [
-        {
-          "id": "consultations",
-          "label": "Consultas",
-          "order": 50
-        }
-      ],
-      "pages": [
-        {
-          "id": "consultations.general",
-          "group": "consultations",
-          "label": "General",
-          "icon": "assets/icons/general.svg",
-          "order": 10
-        }
-      ],
       "sections": [
         {
           "id": "consultations.general.main",
@@ -143,6 +127,44 @@
               ]
             }
           ]
+        },
+        {
+          "id": "consultations.formulario",
+          "page": "consultations.general",
+          "label": "Formulario",
+          "order": 20,
+          "items": [
+            {
+              "key": "consultations.prefillVitals",
+              "type": "boolean",
+              "label": "Prellenar signos vitales",
+              "description": "Al crear una consulta, prellenar peso, temperatura, FC, FR y BCS con los valores de la última consulta del paciente",
+              "default": true,
+              "tags": [
+                "consultations",
+                "prefillvitals",
+                "prellenar",
+                "signos",
+                "vitales"
+              ]
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "id": "consultations",
+          "label": "Consultas",
+          "order": 50
+        }
+      ],
+      "pages": [
+        {
+          "id": "consultations.general",
+          "group": "consultations",
+          "label": "General",
+          "icon": "assets/icons/general.svg",
+          "order": 10
         }
       ]
     }

--- a/drizzle/0003_vital_signs_and_physical_exam.sql
+++ b/drizzle/0003_vital_signs_and_physical_exam.sql
@@ -1,0 +1,11 @@
+-- Agregar signos vitales completos (FC, FR, BCS) y examen fisico estructurado
+-- heart_rate: frecuencia cardiaca (latidos por minuto)
+-- respiratory_rate: frecuencia respiratoria (respiraciones por minuto)
+-- body_condition_score: escala 1-9 (BCS)
+-- physical_exam_systems: examen fisico por sistemas como JSONB
+
+ALTER TABLE "module_consultations_consultations"
+  ADD COLUMN IF NOT EXISTS "heart_rate" integer,
+  ADD COLUMN IF NOT EXISTS "respiratory_rate" integer,
+  ADD COLUMN IF NOT EXISTS "body_condition_score" numeric,
+  ADD COLUMN IF NOT EXISTS "physical_exam_systems" jsonb;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1774393200000,
       "tag": "0002_structured_medication_fields",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1774944000000,
+      "tag": "0003_vital_signs_and_physical_exam",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "./server": {
       "types": "./dist/server.d.ts",
       "default": "./dist/server.js"
+    },
+    "./constants/medication": {
+      "types": "./dist/constants/medication.d.ts",
+      "default": "./dist/constants/medication.js"
     }
   },
   "files": [

--- a/src/components/ConsultationDetail.tsx
+++ b/src/components/ConsultationDetail.tsx
@@ -8,7 +8,7 @@ import { getHostReact, getHostUI, useViewContributions, actions } from '@coongro
 import { useConsultation } from '../hooks/useConsultation.js';
 import { useConsultationsSettings } from '../hooks/useConsultationsSettings.js';
 import type { ConsultationDetailProps, PetInfo } from '../types/components.js';
-import type { ConsultationService } from '../types/consultation.js';
+import type { ConsultationService, PhysicalExamSystem } from '../types/consultation.js';
 import {
   formatConsultationDateTime,
   formatReasonCategory,
@@ -17,6 +17,8 @@ import {
 import { formatCurrency } from '../utils/price.js';
 
 import { MedicationList } from './MedicationList.js';
+import { PhysicalExamSummary } from './PhysicalExamSummary.js';
+import { VitalSignCard } from './VitalSignCard.js';
 
 const React = getHostReact();
 const UI = getHostUI();
@@ -164,7 +166,8 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
     { label: 'Notas', value: c.notes },
   ].filter((s) => s.value);
 
-  const hasVitals = c.weight_kg || c.temperature;
+  const hasVitals =
+    c.weight_kg || c.temperature || c.heart_rate || c.respiratory_rate || c.body_condition_score;
   const servicesTotal = services.reduce(
     (acc: number, s: ConsultationService) => acc + (parseFloat(s.subtotal) || 0),
     0
@@ -334,53 +337,35 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
               'div',
               { className: 'grid grid-cols-2 gap-3' },
               c.weight_kg &&
-                React.createElement(
-                  'div',
-                  { className: 'flex items-center gap-2 p-3 rounded-lg bg-cg-bg-secondary' },
-                  React.createElement(UI.DynamicIcon, {
-                    icon: 'Scale',
-                    size: 16,
-                    className: 'text-cg-text-muted shrink-0',
-                  }),
-                  React.createElement(
-                    'div',
-                    null,
-                    React.createElement(
-                      'span',
-                      { className: 'text-xs text-cg-text-muted block' },
-                      'Peso'
-                    ),
-                    React.createElement(
-                      'span',
-                      { className: 'text-sm font-semibold text-cg-text' },
-                      `${c.weight_kg} kg`
-                    )
-                  )
-                ),
+                React.createElement(VitalSignCard, {
+                  icon: 'Scale',
+                  label: 'Peso',
+                  value: `${c.weight_kg} kg`,
+                }),
               c.temperature &&
-                React.createElement(
-                  'div',
-                  { className: 'flex items-center gap-2 p-3 rounded-lg bg-cg-bg-secondary' },
-                  React.createElement(UI.DynamicIcon, {
-                    icon: 'Thermometer',
-                    size: 16,
-                    className: 'text-cg-text-muted shrink-0',
-                  }),
-                  React.createElement(
-                    'div',
-                    null,
-                    React.createElement(
-                      'span',
-                      { className: 'text-xs text-cg-text-muted block' },
-                      'Temp.'
-                    ),
-                    React.createElement(
-                      'span',
-                      { className: 'text-sm font-semibold text-cg-text' },
-                      `${c.temperature}°C`
-                    )
-                  )
-                )
+                React.createElement(VitalSignCard, {
+                  icon: 'Thermometer',
+                  label: 'Temp.',
+                  value: `${c.temperature}°C`,
+                }),
+              c.heart_rate &&
+                React.createElement(VitalSignCard, {
+                  icon: 'HeartPulse',
+                  label: 'FC',
+                  value: `${c.heart_rate} lpm`,
+                }),
+              c.respiratory_rate &&
+                React.createElement(VitalSignCard, {
+                  icon: 'Wind',
+                  label: 'FR',
+                  value: `${c.respiratory_rate} rpm`,
+                }),
+              c.body_condition_score &&
+                React.createElement(VitalSignCard, {
+                  icon: 'Gauge',
+                  label: 'BCS',
+                  value: `${c.body_condition_score}/9`,
+                })
             )
           ),
 
@@ -485,6 +470,40 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
                 // Separador entre secciones (excepto la última)
                 idx < clinicalSections.length - 1 && React.createElement(UI.Separator, null)
               )
+            )
+          ),
+
+        // Examen físico por sistemas (si hay datos)
+        c.physical_exam_systems &&
+          Array.isArray(c.physical_exam_systems) &&
+          c.physical_exam_systems.some((s: PhysicalExamSystem) => s.status === 'ABN' || s.notes) &&
+          React.createElement(
+            UI.Card,
+            { className: 'overflow-hidden' },
+            React.createElement(
+              'div',
+              {
+                className:
+                  'px-5 py-3 border-b border-cg-border bg-cg-bg-secondary flex items-center gap-2',
+              },
+              React.createElement(UI.DynamicIcon, {
+                icon: 'Stethoscope',
+                size: 15,
+                className: 'text-cg-text-muted',
+              }),
+              React.createElement(
+                'h2',
+                { className: 'text-sm font-semibold text-cg-text' },
+                'Examen físico por sistemas'
+              )
+            ),
+            React.createElement(
+              'div',
+              { className: 'p-4' },
+              React.createElement(PhysicalExamSummary, {
+                systems: c.physical_exam_systems,
+                onlyAbnormal: false,
+              })
             )
           ),
 

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -32,6 +32,7 @@ import {
   type ServiceLineInput,
 } from '../types/consultation.js';
 
+import { ExamSystemRow } from './ExamSystemRow.js';
 import { MedicationFormList } from './MedicationFormList.js';
 import { ServiceLineForm } from './ServiceLineForm.js';
 
@@ -542,42 +543,12 @@ export function ConsultationForm(props: ConsultationFormProps) {
           'div',
           { className: 'flex flex-col gap-2' },
           ...examSystems.map((sys, idx) =>
-            React.createElement(
-              'div',
-              {
-                key: sys.system,
-                className: `flex items-start gap-2 p-2 rounded-lg ${
-                  sys.status === 'ABN' ? 'bg-cg-danger-bg' : 'bg-cg-bg-secondary'
-                }`,
-              },
-              // Toggle WNL/ABN
-              React.createElement(
-                UI.Button,
-                {
-                  type: 'button',
-                  variant: sys.status === 'ABN' ? 'destructive' : 'outline',
-                  size: 'sm',
-                  className: 'shrink-0 w-12 text-xs font-mono',
-                  onClick: () => handleExamStatusToggle(idx),
-                },
-                sys.status
-              ),
-              // Nombre del sistema
-              React.createElement(
-                'span',
-                { className: 'text-sm text-cg-text pt-1.5 w-40 shrink-0 truncate' },
-                sys.system
-              ),
-              // Notas (visible siempre pero relevante cuando ABN)
-              React.createElement(UI.Input, {
-                type: 'text',
-                value: sys.notes,
-                onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                  handleExamNotesChange(idx, e.target.value),
-                placeholder: sys.status === 'ABN' ? 'Describir hallazgo...' : 'Sin observaciones',
-                className: 'flex-1 min-w-0 text-sm',
-              })
-            )
+            React.createElement(ExamSystemRow, {
+              key: sys.system,
+              system: sys,
+              onStatusToggle: () => handleExamStatusToggle(idx),
+              onNotesChange: (value: string) => handleExamNotesChange(idx, value),
+            })
           )
         ),
 

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -1,6 +1,16 @@
 /**
- * Formulario para crear/editar consultas con secciones colapsables de datos clínicos.
+ * Formulario para crear/editar consultas.
+ * Organizado siguiendo flujo clínico SOAP:
+ *   1. Datos básicos (vet, fecha) + Selector de paciente
+ *   2. Signos vitales (peso, temperatura, FC, FR, BCS)
+ *   3. S — Motivo + Anamnesis
+ *   4. O — Examen físico por sistemas
+ *   5. A — Diagnóstico
+ *   6. P — Tratamiento + Medicamentos + Seguimiento
+ *   7. Servicios prestados (facturación)
  */
+import { PetPicker } from '@coongro/patients';
+import type { Pet } from '@coongro/patients';
 import {
   getHostReact,
   getHostUI,
@@ -15,8 +25,12 @@ import { useConsultation } from '../hooks/useConsultation.js';
 import { useConsultationMutations } from '../hooks/useConsultationMutations.js';
 import { useConsultationsSettings } from '../hooks/useConsultationsSettings.js';
 import type { ConsultationFormProps } from '../types/components.js';
-import type { MedicationInput, ServiceLineInput } from '../types/consultation.js';
-// ALL_REASON_CATEGORIES y REASON_CATEGORY_LABELS removidos del form (chips eliminados del diseño v3)
+import {
+  EXAM_SYSTEMS,
+  type MedicationInput,
+  type PhysicalExamSystem,
+  type ServiceLineInput,
+} from '../types/consultation.js';
 
 import { MedicationFormList } from './MedicationFormList.js';
 import { ServiceLineForm } from './ServiceLineForm.js';
@@ -25,6 +39,9 @@ const React = getHostReact();
 const UI = getHostUI();
 const { useState, useCallback, useEffect, useRef, useMemo } = React;
 
+const FIELD_GAP = 'flex flex-col gap-1';
+const GRID_2 = 'grid grid-cols-2 gap-3';
+
 function SectionHeader({ icon, title }: { icon: string; title: string }) {
   return React.createElement(
     'h3',
@@ -32,6 +49,10 @@ function SectionHeader({ icon, title }: { icon: string; title: string }) {
     React.createElement(UI.DynamicIcon, { icon, size: 14, className: 'text-cg-text-muted' }),
     title
   );
+}
+
+function buildDefaultExamSystems(): PhysicalExamSystem[] {
+  return EXAM_SYSTEMS.map((system) => ({ system, status: 'WNL' as const, notes: '' }));
 }
 
 export function ConsultationForm(props: ConsultationFormProps) {
@@ -49,23 +70,31 @@ export function ConsultationForm(props: ConsultationFormProps) {
   const isEditing = !!consultationId;
   const saving = creating || updating;
 
-  // Estado del formulario
+  // --- Estado del formulario ---
+  const [selectedPetId, setSelectedPetId] = useState(petId ?? defaults?.pet_id ?? '');
   const [vetName, setVetName] = useState(defaults?.vet_name ?? '');
   const [date, setDate] = useState(defaults?.date ?? new Date().toISOString().slice(0, 16));
+
+  // Signos vitales
   const [weightKg, setWeightKg] = useState(defaults?.weight_kg ?? '');
   const [temperature, setTemperature] = useState(defaults?.temperature ?? '');
+  const [heartRate, setHeartRate] = useState('');
+  const [respiratoryRate, setRespiratoryRate] = useState('');
+  const [bcs, setBcs] = useState('');
+
+  // SOAP
   const [reason, setReason] = useState(defaults?.reason ?? '');
-  const [clinicalExamOpen, setClinicalExamOpen] = useState(false);
   const [anamnesis, setAnamnesis] = useState(defaults?.anamnesis ?? '');
-  const [physicalExam, setPhysicalExam] = useState(defaults?.physical_exam ?? '');
+  const [examSystems, setExamSystems] = useState<PhysicalExamSystem[]>(buildDefaultExamSystems);
+  const [physicalExamNotes, setPhysicalExamNotes] = useState(defaults?.physical_exam ?? '');
   const [diagnosis, setDiagnosis] = useState(defaults?.diagnosis ?? '');
   const [treatment, setTreatment] = useState(defaults?.treatment ?? '');
+  const [medications, setMedications] = useState<MedicationInput[]>(defaults?.medications ?? []);
   const [followUpDate, setFollowUpDate] = useState(defaults?.follow_up_date ?? '');
   const [notes, setNotes] = useState(defaults?.notes ?? '');
-  const [medications, setMedications] = useState<MedicationInput[]>(defaults?.medications ?? []);
-  const [serviceLines, setServiceLines] = useState<ServiceLineInput[]>(defaults?.services ?? []);
 
-  // Catálogo de servicios para ServiceLineForm
+  // Servicios
+  const [serviceLines, setServiceLines] = useState<ServiceLineInput[]>(defaults?.services ?? []);
   const [serviceCatalog, setServiceCatalog] = useState<Product[]>([]);
   const [serviceCategories, setServiceCategories] = useState<Category[]>([]);
   const [catalogLoading, setCatalogLoading] = useState(true);
@@ -109,7 +138,6 @@ export function ConsultationForm(props: ConsultationFormProps) {
     })();
   }, []);
 
-  // Subcategorías de servicios para el modal de creación
   const serviceSubcategories = useMemo(() => {
     const root = serviceCategories.find((c: Category) => c.slug === ROOT_SERVICE_CATEGORY_SLUG);
     if (!root) return [];
@@ -120,15 +148,24 @@ export function ConsultationForm(props: ConsultationFormProps) {
     setServiceCatalog((prev) => [...prev, product]);
   }, []);
 
-  // Contribuciones de otros plugins (ej: vet-pharmacy inyecta selector de medicamentos)
   const { sections: contributedSections } = useViewContributions('consultations.form.open', {
     onMedicationsChange: setMedications,
   });
 
-  // Precargar peso del paciente al crear consulta nueva
+  // --- PetPicker: sincronizar petId de prop ---
+  useEffect(() => {
+    if (petId) setSelectedPetId(petId);
+  }, [petId]);
+
+  const handlePetSelect = useCallback((pet: Pet | null) => {
+    setSelectedPetId(pet?.id ?? '');
+    if (pet?.weight_kg) setWeightKg(pet.weight_kg);
+  }, []);
+
+  // Precargar peso del paciente
   useEffect(() => {
     if (isEditing || weightKg) return;
-    const targetPetId = petId ?? defaults?.pet_id;
+    const targetPetId = selectedPetId || defaults?.pet_id;
     if (!targetPetId) return;
     void (async () => {
       try {
@@ -141,7 +178,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
         // patients plugin puede no estar instalado
       }
     })();
-  }, [petId, defaults?.pet_id, isEditing, weightKg]);
+  }, [selectedPetId, defaults?.pet_id, isEditing, weightKg]);
 
   // Cargar defaults del settings
   useEffect(() => {
@@ -152,20 +189,25 @@ export function ConsultationForm(props: ConsultationFormProps) {
 
   // Cargar datos existentes al editar
   useEffect(() => {
-    if (existing) {
-      setVetName(existing.vet_name);
-      setDate(existing.date.slice(0, 16));
-      setWeightKg(existing.weight_kg ?? '');
-      setTemperature(existing.temperature ?? '');
-      setReason(existing.reason);
-      if (existing.anamnesis || existing.physical_exam) setClinicalExamOpen(true);
-      setAnamnesis(existing.anamnesis ?? '');
-      setPhysicalExam(existing.physical_exam ?? '');
-      setDiagnosis(existing.diagnosis ?? '');
-      setTreatment(existing.treatment ?? '');
-      setFollowUpDate(existing.follow_up_date ?? '');
-      setNotes(existing.notes ?? '');
+    if (!existing) return;
+    setVetName(existing.vet_name);
+    setDate(existing.date.slice(0, 16));
+    setWeightKg(existing.weight_kg ?? '');
+    setTemperature(existing.temperature ?? '');
+    setHeartRate(existing.heart_rate !== null ? String(existing.heart_rate) : '');
+    setRespiratoryRate(existing.respiratory_rate !== null ? String(existing.respiratory_rate) : '');
+    setBcs(existing.body_condition_score ?? '');
+    setReason(existing.reason);
+    setAnamnesis(existing.anamnesis ?? '');
+    if (existing.physical_exam_systems && Array.isArray(existing.physical_exam_systems)) {
+      setExamSystems(existing.physical_exam_systems);
     }
+    setPhysicalExamNotes(existing.physical_exam ?? '');
+    setDiagnosis(existing.diagnosis ?? '');
+    setTreatment(existing.treatment ?? '');
+    setFollowUpDate(existing.follow_up_date ?? '');
+    setNotes(existing.notes ?? '');
+    setSelectedPetId(existing.pet_id);
   }, [existing]);
 
   useEffect(() => {
@@ -200,6 +242,18 @@ export function ConsultationForm(props: ConsultationFormProps) {
     }
   }, [existingServices]);
 
+  // --- Exam systems handlers ---
+  const handleExamStatusToggle = useCallback((index: number) => {
+    setExamSystems((prev) =>
+      prev.map((s, i) => (i === index ? { ...s, status: s.status === 'WNL' ? 'ABN' : 'WNL' } : s))
+    );
+  }, []);
+
+  const handleExamNotesChange = useCallback((index: number, value: string) => {
+    setExamSystems((prev) => prev.map((s, i) => (i === index ? { ...s, notes: value } : s)));
+  }, []);
+
+  // --- Submit ---
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
@@ -213,52 +267,50 @@ export function ConsultationForm(props: ConsultationFormProps) {
         return;
       }
 
-      // Filtrar medicamentos vacios
       const validMeds = medications.filter((m: MedicationInput) => m.name.trim());
-
-      // Filtrar service lines vacias
       const validServices = serviceLines.filter((s: ServiceLineInput) => s.product_name.trim());
+
+      // Solo guardar sistemas con hallazgos (ABN o con notas)
+      const examData = examSystems.some((s) => s.status === 'ABN' || s.notes.trim())
+        ? examSystems
+        : null;
+
+      const sharedData = {
+        vet_name: vetName.trim(),
+        date: new Date(date).toISOString(),
+        weight_kg: weightKg || null,
+        temperature: temperature || null,
+        heart_rate: heartRate ? parseInt(heartRate, 10) : null,
+        respiratory_rate: respiratoryRate ? parseInt(respiratoryRate, 10) : null,
+        body_condition_score: bcs || null,
+        reason: reason.trim(),
+        reason_category: null,
+        anamnesis: anamnesis.trim() || null,
+        physical_exam: physicalExamNotes.trim() || null,
+        physical_exam_systems: examData,
+        diagnosis: diagnosis.trim() || null,
+        treatment: treatment.trim() || null,
+        follow_up_date: followUpDate || null,
+        follow_up_notes: null,
+        notes: notes.trim() || null,
+      };
 
       if (isEditing && consultationId) {
         const result = await update(consultationId, {
-          vet_name: vetName.trim(),
-          date: new Date(date).toISOString(),
-          weight_kg: weightKg || null,
-          temperature: temperature || null,
-          reason: reason.trim(),
-          reason_category: null,
-          anamnesis: anamnesis.trim() || null,
-          physical_exam: physicalExam.trim() || null,
-          diagnosis: diagnosis.trim() || null,
-          treatment: treatment.trim() || null,
-          follow_up_date: followUpDate || null,
-          follow_up_notes: null,
-          notes: notes.trim() || null,
+          ...sharedData,
           services: validServices,
         });
         if (result && onSuccess) onSuccess(result);
       } else {
-        const targetPetId = petId ?? defaults?.pet_id;
+        const targetPetId = selectedPetId || defaults?.pet_id;
         if (!targetPetId) {
-          toast.error('Error', 'No se especificó un paciente');
+          toast.error('Error', 'Seleccioná un paciente');
           return;
         }
 
         const result = await create({
+          ...sharedData,
           pet_id: targetPetId,
-          vet_name: vetName.trim(),
-          date: new Date(date).toISOString(),
-          weight_kg: weightKg || null,
-          temperature: temperature || null,
-          reason: reason.trim(),
-          reason_category: null,
-          anamnesis: anamnesis.trim() || null,
-          physical_exam: physicalExam.trim() || null,
-          diagnosis: diagnosis.trim() || null,
-          treatment: treatment.trim() || null,
-          follow_up_date: followUpDate || null,
-          follow_up_notes: null,
-          notes: notes.trim() || null,
           medications: validMeds,
           services: validServices,
         });
@@ -267,16 +319,20 @@ export function ConsultationForm(props: ConsultationFormProps) {
     },
     [
       consultationId,
-      petId,
+      selectedPetId,
       defaults,
       isEditing,
       vetName,
       date,
       weightKg,
       temperature,
+      heartRate,
+      respiratoryRate,
+      bcs,
       reason,
       anamnesis,
-      physicalExam,
+      examSystems,
+      physicalExamNotes,
       diagnosis,
       treatment,
       followUpDate,
@@ -290,11 +346,14 @@ export function ConsultationForm(props: ConsultationFormProps) {
     ]
   );
 
+  // Si no hay petId, necesitamos mostrar PetPicker
+  const needsPetPicker = !petId && !consultationId;
+
   return React.createElement(
     'form',
     { onSubmit: handleSubmit, className: `flex flex-col gap-4 ${className}` },
 
-    // Seccion 1: Datos basicos
+    // ── Sección 1: Datos básicos + Paciente ──
     React.createElement(
       UI.Card,
       { className: 'p-4' },
@@ -302,12 +361,26 @@ export function ConsultationForm(props: ConsultationFormProps) {
         'div',
         { className: 'flex flex-col gap-3' },
         React.createElement(SectionHeader, { icon: 'ClipboardList', title: 'Datos básicos' }),
-        React.createElement(
-          'div',
-          { className: 'grid grid-cols-2 gap-3' },
+
+        // PetPicker (solo cuando no viene petId por parámetro)
+        needsPetPicker &&
           React.createElement(
             'div',
-            { className: 'flex flex-col gap-1' },
+            { className: FIELD_GAP },
+            React.createElement(UI.Label, null, 'Paciente *'),
+            React.createElement(PetPicker, {
+              value: selectedPetId || undefined,
+              onChange: handlePetSelect,
+              placeholder: 'Buscar paciente por nombre, raza o microchip...',
+            })
+          ),
+
+        React.createElement(
+          'div',
+          { className: GRID_2 },
+          React.createElement(
+            'div',
+            { className: FIELD_GAP },
             React.createElement(UI.Label, null, 'Veterinario *'),
             React.createElement(UI.Input, {
               type: 'text',
@@ -319,7 +392,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
           ),
           React.createElement(
             'div',
-            { className: 'flex flex-col gap-1' },
+            { className: FIELD_GAP },
             React.createElement(UI.Label, null, 'Fecha y hora'),
             React.createElement(UI.Input, {
               type: 'datetime-local',
@@ -327,13 +400,24 @@ export function ConsultationForm(props: ConsultationFormProps) {
               onChange: (e: React.ChangeEvent<HTMLInputElement>) => setDate(e.target.value),
             })
           )
-        ),
+        )
+      )
+    ),
+
+    // ── Sección 2: Signos vitales ──
+    React.createElement(
+      UI.Card,
+      { className: 'p-4' },
+      React.createElement(
+        'div',
+        { className: 'flex flex-col gap-3' },
+        React.createElement(SectionHeader, { icon: 'HeartPulse', title: 'Signos vitales' }),
         React.createElement(
           'div',
-          { className: 'grid grid-cols-2 gap-3' },
+          { className: 'grid grid-cols-3 sm:grid-cols-5 gap-3' },
           React.createElement(
             'div',
-            { className: 'flex flex-col gap-1' },
+            { className: FIELD_GAP },
             React.createElement(UI.Label, null, 'Peso (kg)'),
             React.createElement(UI.Input, {
               type: 'number',
@@ -342,13 +426,13 @@ export function ConsultationForm(props: ConsultationFormProps) {
               max: '200',
               value: weightKg,
               onChange: (e: React.ChangeEvent<HTMLInputElement>) => setWeightKg(e.target.value),
-              placeholder: 'ej: 28.5',
+              placeholder: '28.5',
             })
           ),
           React.createElement(
             'div',
-            { className: 'flex flex-col gap-1' },
-            React.createElement(UI.Label, null, 'Temperatura (°C)'),
+            { className: FIELD_GAP },
+            React.createElement(UI.Label, null, 'Temp. (°C)'),
             React.createElement(UI.Input, {
               type: 'number',
               step: '0.1',
@@ -356,25 +440,69 @@ export function ConsultationForm(props: ConsultationFormProps) {
               max: '42',
               value: temperature,
               onChange: (e: React.ChangeEvent<HTMLInputElement>) => setTemperature(e.target.value),
-              placeholder: 'ej: 38.5',
+              placeholder: '38.5',
+            })
+          ),
+          React.createElement(
+            'div',
+            { className: FIELD_GAP },
+            React.createElement(UI.Label, null, 'FC (lpm)'),
+            React.createElement(UI.Input, {
+              type: 'number',
+              min: '0',
+              max: '300',
+              value: heartRate,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) => setHeartRate(e.target.value),
+              placeholder: '120',
+            })
+          ),
+          React.createElement(
+            'div',
+            { className: FIELD_GAP },
+            React.createElement(UI.Label, null, 'FR (rpm)'),
+            React.createElement(UI.Input, {
+              type: 'number',
+              min: '0',
+              max: '100',
+              value: respiratoryRate,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                setRespiratoryRate(e.target.value),
+              placeholder: '20',
+            })
+          ),
+          React.createElement(
+            'div',
+            { className: FIELD_GAP },
+            React.createElement(UI.Label, null, 'BCS (1-9)'),
+            React.createElement(UI.Input, {
+              type: 'number',
+              min: '1',
+              max: '9',
+              step: '0.5',
+              value: bcs,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) => setBcs(e.target.value),
+              placeholder: '5',
             })
           )
         )
       )
     ),
 
-    // Seccion 2: Servicios prestados (siempre visible) + Motivo
+    // ── Sección 3 (S): Motivo + Anamnesis ──
     React.createElement(
       UI.Card,
       { className: 'p-4' },
       React.createElement(
         'div',
         { className: 'flex flex-col gap-3' },
-        React.createElement(SectionHeader, { icon: 'Receipt', title: 'Servicios prestados' }),
+        React.createElement(SectionHeader, {
+          icon: 'MessageSquare',
+          title: 'S — Motivo y anamnesis',
+        }),
         React.createElement(
           'div',
-          { className: 'flex flex-col gap-1' },
-          React.createElement(UI.Label, null, 'Motivo *'),
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'Motivo de consulta *'),
           React.createElement(UI.Input, {
             type: 'text',
             value: reason,
@@ -383,106 +511,120 @@ export function ConsultationForm(props: ConsultationFormProps) {
             required: true,
           })
         ),
-        React.createElement(ServiceLineForm, {
-          services: serviceLines,
-          onChange: setServiceLines,
-          catalog: serviceCatalog,
-          categories: serviceSubcategories,
-          catalogLoading,
-          onProductCreated: handleProductCreated,
-          showPrices: consultSettings.showPrices,
-        })
-      )
-    ),
-
-    // Seccion 3: Examen clínico (colapsable, cerrado por defecto)
-    React.createElement(
-      UI.Card,
-      { className: 'p-4' },
-      React.createElement(
-        'div',
-        { className: 'flex flex-col gap-3' },
         React.createElement(
           'div',
-          {
-            className: 'flex items-center gap-2 cursor-pointer select-none',
-            onClick: () => setClinicalExamOpen(!clinicalExamOpen),
-          },
-          React.createElement(
-            'span',
-            { className: 'text-xs text-cg-text-muted' },
-            clinicalExamOpen ? '\u25BC' : '\u25B6'
-          ),
-          React.createElement(UI.DynamicIcon, {
-            icon: 'Stethoscope',
-            size: 14,
-            className: 'text-cg-text-muted',
-          }),
-          React.createElement(
-            'h3',
-            { className: 'text-sm font-medium text-cg-text-muted' },
-            'Examen clínico'
-          ),
-          !clinicalExamOpen &&
-            (anamnesis || physicalExam) &&
-            React.createElement(UI.Badge, { variant: 'secondary', size: 'sm' }, 'Con datos')
-        ),
-        clinicalExamOpen &&
-          React.createElement(
-            'div',
-            { className: 'flex flex-col gap-1' },
-            React.createElement(UI.Label, null, 'Anamnesis'),
-            React.createElement(UI.Textarea, {
-              value: anamnesis,
-              onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setAnamnesis(e.target.value),
-              placeholder: 'Lo que reporta el dueño...',
-              rows: 2,
-            })
-          ),
-        clinicalExamOpen &&
-          React.createElement(
-            'div',
-            { className: 'flex flex-col gap-1' },
-            React.createElement(UI.Label, null, 'Examen físico'),
-            React.createElement(UI.Textarea, {
-              value: physicalExam,
-              onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setPhysicalExam(e.target.value),
-              placeholder: 'Hallazgos del examen...',
-              rows: 2,
-            })
-          )
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'Anamnesis'),
+          React.createElement(UI.Textarea, {
+            value: anamnesis,
+            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setAnamnesis(e.target.value),
+            placeholder: 'Lo que reporta el dueño: síntomas, duración, cambios de hábitos...',
+            rows: 3,
+          })
+        )
       )
     ),
 
-    // Seccion 4: Diagnóstico
+    // ── Sección 4 (O): Examen físico por sistemas ──
     React.createElement(
       UI.Card,
       { className: 'p-4' },
       React.createElement(
         'div',
         { className: 'flex flex-col gap-3' },
-        React.createElement(SectionHeader, { icon: 'SearchCheck', title: 'Diagnóstico' }),
+        React.createElement(SectionHeader, {
+          icon: 'Stethoscope',
+          title: 'O — Examen físico',
+        }),
+
+        // Grid de sistemas con toggle WNL/ABN
+        React.createElement(
+          'div',
+          { className: 'flex flex-col gap-2' },
+          ...examSystems.map((sys, idx) =>
+            React.createElement(
+              'div',
+              {
+                key: sys.system,
+                className: `flex items-start gap-2 p-2 rounded-lg ${
+                  sys.status === 'ABN' ? 'bg-cg-danger-bg' : 'bg-cg-bg-secondary'
+                }`,
+              },
+              // Toggle WNL/ABN
+              React.createElement(
+                UI.Button,
+                {
+                  type: 'button',
+                  variant: sys.status === 'ABN' ? 'destructive' : 'outline',
+                  size: 'sm',
+                  className: 'shrink-0 w-12 text-xs font-mono',
+                  onClick: () => handleExamStatusToggle(idx),
+                },
+                sys.status
+              ),
+              // Nombre del sistema
+              React.createElement(
+                'span',
+                { className: 'text-sm text-cg-text pt-1.5 w-36 shrink-0' },
+                sys.system
+              ),
+              // Notas (visible siempre pero relevante cuando ABN)
+              React.createElement(UI.Input, {
+                type: 'text',
+                value: sys.notes,
+                onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                  handleExamNotesChange(idx, e.target.value),
+                placeholder: sys.status === 'ABN' ? 'Describir hallazgo...' : 'Sin observaciones',
+                className: 'flex-1 text-sm',
+              })
+            )
+          )
+        ),
+
+        // Notas generales del examen (textarea legacy, por compatibilidad)
+        React.createElement(
+          'div',
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'Notas generales del examen'),
+          React.createElement(UI.Textarea, {
+            value: physicalExamNotes,
+            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              setPhysicalExamNotes(e.target.value),
+            placeholder: 'Observaciones adicionales del examen físico...',
+            rows: 2,
+          })
+        )
+      )
+    ),
+
+    // ── Sección 5 (A): Diagnóstico ──
+    React.createElement(
+      UI.Card,
+      { className: 'p-4' },
+      React.createElement(
+        'div',
+        { className: 'flex flex-col gap-3' },
+        React.createElement(SectionHeader, { icon: 'SearchCheck', title: 'A — Diagnóstico' }),
         React.createElement(UI.Textarea, {
           value: diagnosis,
           onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setDiagnosis(e.target.value),
-          placeholder: 'Diagnóstico...',
+          placeholder: 'Diagnóstico presuntivo o definitivo...',
           rows: 2,
         })
       )
     ),
 
-    // Seccion 5: Tratamiento + Medicamentos
+    // ── Sección 6 (P): Tratamiento + Medicamentos + Seguimiento ──
     React.createElement(
       UI.Card,
       { className: 'p-4' },
       React.createElement(
         'div',
         { className: 'flex flex-col gap-3' },
-        React.createElement(SectionHeader, { icon: 'Pill', title: 'Tratamiento' }),
+        React.createElement(SectionHeader, { icon: 'Pill', title: 'P — Plan de tratamiento' }),
         React.createElement(
           'div',
-          { className: 'flex flex-col gap-1' },
+          { className: FIELD_GAP },
           React.createElement(UI.Label, null, 'Indicaciones generales'),
           React.createElement(UI.Input, {
             type: 'text',
@@ -492,7 +634,6 @@ export function ConsultationForm(props: ConsultationFormProps) {
           })
         ),
         React.createElement(UI.Label, null, 'Medicación'),
-        // Si hay contribuciones de otros plugins, usarlas; si no, fallback al formulario nativo
         ...(contributedSections.length > 0
           ? contributedSections.map((s, i) =>
               React.createElement(
@@ -507,24 +648,15 @@ export function ConsultationForm(props: ConsultationFormProps) {
                 medications,
                 onChange: setMedications,
               }),
-            ])
-      )
-    ),
-
-    // Seccion 6: Seguimiento (notas unificadas)
-    React.createElement(
-      UI.Card,
-      { className: 'p-4' },
-      React.createElement(
-        'div',
-        { className: 'flex flex-col gap-3' },
+            ]),
+        React.createElement(UI.Separator, { className: 'my-1' }),
         React.createElement(SectionHeader, { icon: 'CalendarCheck', title: 'Seguimiento' }),
         React.createElement(
           'div',
-          { className: 'grid grid-cols-2 gap-3' },
+          { className: GRID_2 },
           React.createElement(
             'div',
-            { className: 'flex flex-col gap-1' },
+            { className: FIELD_GAP },
             React.createElement(UI.Label, null, 'Próximo control'),
             React.createElement(UI.Input, {
               type: 'date',
@@ -534,7 +666,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
           ),
           React.createElement(
             'div',
-            { className: 'flex flex-col gap-1' },
+            { className: FIELD_GAP },
             React.createElement(UI.Label, null, 'Notas'),
             React.createElement(UI.Input, {
               type: 'text',
@@ -547,26 +679,39 @@ export function ConsultationForm(props: ConsultationFormProps) {
       )
     ),
 
-    // Botones
+    // ── Sección 7: Servicios prestados ──
+    React.createElement(
+      UI.Card,
+      { className: 'p-4' },
+      React.createElement(
+        'div',
+        { className: 'flex flex-col gap-3' },
+        React.createElement(SectionHeader, { icon: 'Receipt', title: 'Servicios prestados' }),
+        React.createElement(ServiceLineForm, {
+          services: serviceLines,
+          onChange: setServiceLines,
+          catalog: serviceCatalog,
+          categories: serviceSubcategories,
+          catalogLoading,
+          onProductCreated: handleProductCreated,
+          showPrices: consultSettings.showPrices,
+        })
+      )
+    ),
+
+    // ── Botones ──
     React.createElement(
       'div',
       { className: 'flex justify-end gap-3' },
       onCancel &&
         React.createElement(
           UI.Button,
-          {
-            type: 'button',
-            variant: 'outline',
-            onClick: onCancel,
-          },
+          { type: 'button', variant: 'outline', onClick: onCancel },
           'Cancelar'
         ),
       React.createElement(
         UI.Button,
-        {
-          type: 'submit',
-          disabled: saving,
-        },
+        { type: 'submit', disabled: saving },
         saving ? 'Guardando...' : isEditing ? 'Guardar cambios' : 'Registrar consulta'
       )
     )

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -547,7 +547,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
       )
     ),
 
-    // ── Sección 4 (O): Examen físico por sistemas ──
+    // ── Sección 4 (O): Examen físico ──
     React.createElement(
       UI.Card,
       { className: 'p-4' },
@@ -559,24 +559,31 @@ export function ConsultationForm(props: ConsultationFormProps) {
           title: 'O — Examen físico',
         }),
 
-        // Grid de sistemas con toggle WNL/ABN
-        React.createElement(ExamSystemList, {
-          systems: examSystems,
-          onStatusToggle: handleExamStatusToggle,
-          onNotesChange: handleExamNotesChange,
-        }),
+        // Checklist por sistemas (si structuredExam habilitado)
+        consultSettings.structuredExam &&
+          React.createElement(ExamSystemList, {
+            systems: examSystems,
+            onStatusToggle: handleExamStatusToggle,
+            onNotesChange: handleExamNotesChange,
+          }),
 
-        // Notas generales del examen (textarea legacy, por compatibilidad)
+        // Textarea libre (siempre visible como notas adicionales si structured, o como único campo si no)
         React.createElement(
           'div',
           { className: FIELD_GAP },
-          React.createElement(UI.Label, null, 'Notas generales del examen'),
+          React.createElement(
+            UI.Label,
+            null,
+            consultSettings.structuredExam ? 'Notas generales del examen' : 'Examen físico'
+          ),
           React.createElement(UI.Textarea, {
             value: physicalExamNotes,
             onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
               setPhysicalExamNotes(e.target.value),
-            placeholder: 'Observaciones adicionales del examen físico...',
-            rows: 2,
+            placeholder: consultSettings.structuredExam
+              ? 'Observaciones adicionales del examen físico...'
+              : 'Hallazgos del examen físico...',
+            rows: consultSettings.structuredExam ? 2 : 4,
           })
         )
       )

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -541,7 +541,10 @@ export function ConsultationForm(props: ConsultationFormProps) {
         // Grid de sistemas con toggle WNL/ABN
         React.createElement(
           'div',
-          { className: 'flex flex-col gap-2' },
+          {
+            className:
+              'flex flex-col divide-y divide-cg-border rounded-lg border border-cg-border overflow-hidden',
+          },
           ...examSystems.map((sys, idx) =>
             React.createElement(ExamSystemRow, {
               key: sys.system,

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -27,6 +27,7 @@ import { useConsultationsSettings } from '../hooks/useConsultationsSettings.js';
 import type { ConsultationFormProps } from '../types/components.js';
 import {
   EXAM_SYSTEMS,
+  type Consultation,
   type MedicationInput,
   type PhysicalExamSystem,
   type ServiceLineInput,
@@ -163,23 +164,43 @@ export function ConsultationForm(props: ConsultationFormProps) {
     if (pet?.weight_kg) setWeightKg(pet.weight_kg);
   }, []);
 
-  // Precargar peso del paciente
+  // Precargar signos vitales de la última consulta del paciente
+  const vitalsLoadedRef = useRef(false);
   useEffect(() => {
-    if (isEditing || weightKg) return;
+    if (isEditing || vitalsLoadedRef.current) return;
     const targetPetId = selectedPetId || defaults?.pet_id;
     if (!targetPetId) return;
+    vitalsLoadedRef.current = true;
     void (async () => {
+      // Cargar peso desde ficha del paciente
       try {
         const pet = await actions.execute<{ weight_kg: string | null } | undefined>(
           'patients.pets.getById',
           { id: targetPetId }
         );
-        if (pet?.weight_kg) setWeightKg(pet.weight_kg);
+        if (pet?.weight_kg && !weightKg) setWeightKg(pet.weight_kg);
       } catch {
         // patients plugin puede no estar instalado
       }
+
+      // Cargar vitales de la última consulta
+      try {
+        const lastConsultations = await actions.execute<Consultation[]>(
+          'consultations.records.listByPet',
+          { petId: targetPetId, limit: 1 }
+        );
+        const last = lastConsultations?.[0];
+        if (!last) return;
+        if (last.temperature && !temperature) setTemperature(last.temperature);
+        if (last.heart_rate && !heartRate) setHeartRate(String(last.heart_rate));
+        if (last.respiratory_rate && !respiratoryRate)
+          setRespiratoryRate(String(last.respiratory_rate));
+        if (last.body_condition_score && !bcs) setBcs(last.body_condition_score);
+      } catch {
+        // Primera consulta del paciente, sin datos previos
+      }
     })();
-  }, [selectedPetId, defaults?.pet_id, isEditing, weightKg]);
+  }, [selectedPetId, defaults?.pet_id, isEditing]);
 
   // Cargar defaults del settings
   useEffect(() => {

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -32,7 +32,7 @@ import {
   type ServiceLineInput,
 } from '../types/consultation.js';
 
-import { ExamSystemRow } from './ExamSystemRow.js';
+import { ExamSystemList } from './ExamSystemRow.js';
 import { MedicationFormList } from './MedicationFormList.js';
 import { ServiceLineForm } from './ServiceLineForm.js';
 
@@ -539,21 +539,11 @@ export function ConsultationForm(props: ConsultationFormProps) {
         }),
 
         // Grid de sistemas con toggle WNL/ABN
-        React.createElement(
-          'div',
-          {
-            className:
-              'flex flex-col divide-y divide-cg-border rounded-lg border border-cg-border overflow-hidden',
-          },
-          ...examSystems.map((sys, idx) =>
-            React.createElement(ExamSystemRow, {
-              key: sys.system,
-              system: sys,
-              onStatusToggle: () => handleExamStatusToggle(idx),
-              onNotesChange: (value: string) => handleExamNotesChange(idx, value),
-            })
-          )
-        ),
+        React.createElement(ExamSystemList, {
+          systems: examSystems,
+          onStatusToggle: handleExamStatusToggle,
+          onNotesChange: handleExamNotesChange,
+        }),
 
         // Notas generales del examen (textarea legacy, por compatibilidad)
         React.createElement(

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -565,7 +565,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
               // Nombre del sistema
               React.createElement(
                 'span',
-                { className: 'text-sm text-cg-text pt-1.5 w-36 shrink-0' },
+                { className: 'text-sm text-cg-text pt-1.5 w-40 shrink-0 truncate' },
                 sys.system
               ),
               // Notas (visible siempre pero relevante cuando ABN)
@@ -575,7 +575,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
                 onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
                   handleExamNotesChange(idx, e.target.value),
                 placeholder: sys.status === 'ABN' ? 'Describir hallazgo...' : 'Sin observaciones',
-                className: 'flex-1 text-sm',
+                className: 'flex-1 min-w-0 text-sm',
               })
             )
           )

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -167,7 +167,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
   // Precargar signos vitales de la última consulta del paciente
   const vitalsLoadedRef = useRef(false);
   useEffect(() => {
-    if (isEditing || vitalsLoadedRef.current) return;
+    if (isEditing || vitalsLoadedRef.current || !consultSettings.prefillVitals) return;
     const targetPetId = selectedPetId || defaults?.pet_id;
     if (!targetPetId) return;
     vitalsLoadedRef.current = true;

--- a/src/components/ExamSystemRow.tsx
+++ b/src/components/ExamSystemRow.tsx
@@ -7,7 +7,7 @@
  */
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
-import type { PhysicalExamSystem } from '../types/consultation.js';
+import { EXAM_SYSTEM_EXAMPLES, type PhysicalExamSystem } from '../types/consultation.js';
 
 const React = getHostReact();
 const UI = getHostUI();
@@ -61,7 +61,7 @@ export function ExamSystemRow({
       type: 'text',
       value: system.notes,
       onChange: (e: React.ChangeEvent<HTMLInputElement>) => onNotesChange(e.target.value),
-      placeholder: isAbnormal ? 'Hallazgo...' : '',
+      placeholder: EXAM_SYSTEM_EXAMPLES[system.system] ?? '',
       className: 'text-sm h-8',
     })
   );

--- a/src/components/ExamSystemRow.tsx
+++ b/src/components/ExamSystemRow.tsx
@@ -1,0 +1,56 @@
+/**
+ * Fila de examen físico por sistema.
+ * Muestra toggle WNL/ABN + nombre del sistema + input de notas, alineados.
+ * Reutilizable en ConsultationForm y cualquier contexto que necesite
+ * un checklist de examen por sistemas.
+ */
+import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
+import type { PhysicalExamSystem } from '../types/consultation.js';
+
+const React = getHostReact();
+const UI = getHostUI();
+
+export interface ExamSystemRowProps {
+  system: PhysicalExamSystem;
+  onStatusToggle: () => void;
+  onNotesChange: (value: string) => void;
+  className?: string;
+}
+
+export function ExamSystemRow({
+  system,
+  onStatusToggle,
+  onNotesChange,
+  className = '',
+}: ExamSystemRowProps) {
+  const isAbnormal = system.status === 'ABN';
+
+  return React.createElement(
+    'div',
+    {
+      className: `grid grid-cols-[48px_160px_1fr] items-center gap-2 p-2 rounded-lg ${
+        isAbnormal ? 'bg-cg-danger-bg' : 'bg-cg-bg-secondary'
+      } ${className}`,
+    },
+    React.createElement(
+      UI.Button,
+      {
+        type: 'button',
+        variant: isAbnormal ? 'destructive' : 'outline',
+        size: 'sm',
+        className: 'w-12 text-xs font-mono',
+        onClick: onStatusToggle,
+      },
+      system.status
+    ),
+    React.createElement('span', { className: 'text-sm text-cg-text truncate' }, system.system),
+    React.createElement(UI.Input, {
+      type: 'text',
+      value: system.notes,
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) => onNotesChange(e.target.value),
+      placeholder: isAbnormal ? 'Describir hallazgo...' : 'Sin observaciones',
+      className: 'text-sm',
+    })
+  );
+}

--- a/src/components/ExamSystemRow.tsx
+++ b/src/components/ExamSystemRow.tsx
@@ -29,28 +29,35 @@ export function ExamSystemRow({
   return React.createElement(
     'div',
     {
-      className: `grid grid-cols-[48px_160px_1fr] items-center gap-2 p-2 rounded-lg ${
-        isAbnormal ? 'bg-cg-danger-bg' : 'bg-cg-bg-secondary'
+      className: `grid items-center gap-3 py-1.5 px-2 rounded transition-colors ${
+        isAbnormal ? 'bg-cg-danger-bg' : ''
       } ${className}`,
+      style: { gridTemplateColumns: '44px 140px 1fr' },
     },
     React.createElement(
-      UI.Button,
+      'button',
       {
         type: 'button',
-        variant: isAbnormal ? 'destructive' : 'outline',
-        size: 'sm',
-        className: 'w-12 text-xs font-mono',
+        className: `inline-flex items-center justify-center h-7 rounded text-xs font-mono font-medium transition-colors ${
+          isAbnormal ? 'bg-cg-danger text-white' : 'text-cg-text-muted hover:bg-cg-bg-secondary'
+        }`,
         onClick: onStatusToggle,
       },
       system.status
     ),
-    React.createElement('span', { className: 'text-sm text-cg-text truncate' }, system.system),
+    React.createElement(
+      'span',
+      {
+        className: `text-sm truncate ${isAbnormal ? 'text-cg-text font-medium' : 'text-cg-text-muted'}`,
+      },
+      system.system
+    ),
     React.createElement(UI.Input, {
       type: 'text',
       value: system.notes,
       onChange: (e: React.ChangeEvent<HTMLInputElement>) => onNotesChange(e.target.value),
-      placeholder: isAbnormal ? 'Describir hallazgo...' : 'Sin observaciones',
-      className: 'text-sm',
+      placeholder: isAbnormal ? 'Describir hallazgo...' : '',
+      className: 'text-sm h-8',
     })
   );
 }

--- a/src/components/ExamSystemRow.tsx
+++ b/src/components/ExamSystemRow.tsx
@@ -1,6 +1,7 @@
 /**
  * Fila de examen físico por sistema.
  * Muestra toggle WNL/ABN + nombre del sistema + input de notas, alineados.
+ * Responsive: en mobile reduce el ancho del nombre del sistema.
  * Reutilizable en ConsultationForm y cualquier contexto que necesite
  * un checklist de examen por sistemas.
  */
@@ -10,11 +11,13 @@ import type { PhysicalExamSystem } from '../types/consultation.js';
 
 const React = getHostReact();
 const UI = getHostUI();
+const { useState, useEffect, useCallback } = React;
 
 export interface ExamSystemRowProps {
   system: PhysicalExamSystem;
   onStatusToggle: () => void;
   onNotesChange: (value: string) => void;
+  compact?: boolean;
   className?: string;
 }
 
@@ -22,17 +25,19 @@ export function ExamSystemRow({
   system,
   onStatusToggle,
   onNotesChange,
+  compact = false,
   className = '',
 }: ExamSystemRowProps) {
   const isAbnormal = system.status === 'ABN';
+  const gridCols = compact ? '40px 100px 1fr' : '44px 140px 1fr';
 
   return React.createElement(
     'div',
     {
-      className: `grid items-center gap-3 py-1.5 px-2 rounded transition-colors ${
+      className: `grid items-center gap-2 py-1.5 px-2 rounded transition-colors ${
         isAbnormal ? 'bg-cg-danger-bg' : ''
       } ${className}`,
-      style: { gridTemplateColumns: '44px 140px 1fr' },
+      style: { gridTemplateColumns: gridCols },
     },
     React.createElement(
       'button',
@@ -56,8 +61,58 @@ export function ExamSystemRow({
       type: 'text',
       value: system.notes,
       onChange: (e: React.ChangeEvent<HTMLInputElement>) => onNotesChange(e.target.value),
-      placeholder: isAbnormal ? 'Describir hallazgo...' : '',
+      placeholder: isAbnormal ? 'Hallazgo...' : '',
       className: 'text-sm h-8',
     })
+  );
+}
+
+/**
+ * Contenedor responsive para la lista de ExamSystemRow.
+ * Detecta el ancho disponible y pasa compact=true cuando es estrecho.
+ */
+export interface ExamSystemListProps {
+  systems: PhysicalExamSystem[];
+  onStatusToggle: (index: number) => void;
+  onNotesChange: (index: number, value: string) => void;
+  className?: string;
+}
+
+export function ExamSystemList({
+  systems,
+  onStatusToggle,
+  onNotesChange,
+  className = '',
+}: ExamSystemListProps) {
+  const [compact, setCompact] = useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const checkWidth = useCallback(() => {
+    if (containerRef.current) {
+      setCompact(containerRef.current.offsetWidth < 450);
+    }
+  }, []);
+
+  useEffect(() => {
+    checkWidth();
+    window.addEventListener('resize', checkWidth);
+    return () => window.removeEventListener('resize', checkWidth);
+  }, [checkWidth]);
+
+  return React.createElement(
+    'div',
+    {
+      ref: containerRef,
+      className: `flex flex-col divide-y divide-cg-border rounded-lg border border-cg-border overflow-hidden ${className}`,
+    },
+    ...systems.map((sys, idx) =>
+      React.createElement(ExamSystemRow, {
+        key: sys.system,
+        system: sys,
+        compact,
+        onStatusToggle: () => onStatusToggle(idx),
+        onNotesChange: (value: string) => onNotesChange(idx, value),
+      })
+    )
   );
 }

--- a/src/components/PhysicalExamSummary.tsx
+++ b/src/components/PhysicalExamSummary.tsx
@@ -49,7 +49,7 @@ export function PhysicalExamSummary({
         ),
         React.createElement(
           'span',
-          { className: 'text-sm text-cg-text w-36 shrink-0' },
+          { className: 'text-sm text-cg-text w-40 shrink-0 truncate' },
           sys.system
         ),
         sys.notes &&

--- a/src/components/PhysicalExamSummary.tsx
+++ b/src/components/PhysicalExamSummary.tsx
@@ -1,0 +1,60 @@
+/**
+ * Resumen de examen físico por sistemas.
+ * Muestra la lista de sistemas con estado WNL/ABN y notas.
+ * Reutilizable en ConsultationDetail, exports para otros plugins.
+ */
+import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
+import type { PhysicalExamSystem } from '../types/consultation.js';
+
+const React = getHostReact();
+const UI = getHostUI();
+
+export interface PhysicalExamSummaryProps {
+  systems: PhysicalExamSystem[];
+  /** Si true, solo muestra los sistemas con hallazgos (ABN o con notas) */
+  onlyAbnormal?: boolean;
+  className?: string;
+}
+
+export function PhysicalExamSummary({
+  systems,
+  onlyAbnormal = false,
+  className = '',
+}: PhysicalExamSummaryProps) {
+  const filtered = onlyAbnormal ? systems.filter((s) => s.status === 'ABN' || s.notes) : systems;
+
+  if (filtered.length === 0) return null;
+
+  return React.createElement(
+    'div',
+    { className: `flex flex-col gap-1 ${className}` },
+    ...filtered.map((sys) =>
+      React.createElement(
+        'div',
+        {
+          key: sys.system,
+          className: `flex items-center gap-3 py-1.5 px-2 rounded ${
+            sys.status === 'ABN' ? 'bg-cg-danger-bg' : ''
+          }`,
+        },
+        React.createElement(
+          UI.Badge,
+          {
+            variant: sys.status === 'ABN' ? 'destructive' : 'secondary',
+            size: 'sm',
+            className: 'font-mono w-12 justify-center',
+          },
+          sys.status
+        ),
+        React.createElement(
+          'span',
+          { className: 'text-sm text-cg-text w-36 shrink-0' },
+          sys.system
+        ),
+        sys.notes &&
+          React.createElement('span', { className: 'text-sm text-cg-text-muted' }, sys.notes)
+      )
+    )
+  );
+}

--- a/src/components/VitalSignCard.tsx
+++ b/src/components/VitalSignCard.tsx
@@ -1,0 +1,34 @@
+/**
+ * Tarjeta de signo vital reutilizable.
+ * Muestra ícono + label + valor en un formato compacto.
+ * Usado en ConsultationDetail (panel lateral) y potencialmente en otros contextos.
+ */
+import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
+const React = getHostReact();
+const UI = getHostUI();
+
+export interface VitalSignCardProps {
+  icon: string;
+  label: string;
+  value: string;
+  className?: string;
+}
+
+export function VitalSignCard({ icon, label, value, className = '' }: VitalSignCardProps) {
+  return React.createElement(
+    'div',
+    { className: `flex items-center gap-2 p-3 rounded-lg bg-cg-bg-secondary ${className}` },
+    React.createElement(UI.DynamicIcon, {
+      icon,
+      size: 16,
+      className: 'text-cg-text-muted shrink-0',
+    }),
+    React.createElement(
+      'div',
+      null,
+      React.createElement('span', { className: 'text-xs text-cg-text-muted block' }, label),
+      React.createElement('span', { className: 'text-sm font-semibold text-cg-text' }, value)
+    )
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,7 +5,12 @@ export { ConsultationForm } from './ConsultationForm.js';
 export { MedicationList } from './MedicationList.js';
 export { MedicationFormList } from './MedicationFormList.js';
 export { VitalSignCard, type VitalSignCardProps } from './VitalSignCard.js';
-export { ExamSystemRow, type ExamSystemRowProps } from './ExamSystemRow.js';
+export {
+  ExamSystemRow,
+  ExamSystemList,
+  type ExamSystemRowProps,
+  type ExamSystemListProps,
+} from './ExamSystemRow.js';
 export { PhysicalExamSummary, type PhysicalExamSummaryProps } from './PhysicalExamSummary.js';
 export { PriceInput, type PriceInputProps } from './PriceInput.js';
 export {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,8 @@ export { ConsultationDetail } from './ConsultationDetail.js';
 export { ConsultationForm } from './ConsultationForm.js';
 export { MedicationList } from './MedicationList.js';
 export { MedicationFormList } from './MedicationFormList.js';
+export { VitalSignCard, type VitalSignCardProps } from './VitalSignCard.js';
+export { PhysicalExamSummary, type PhysicalExamSummaryProps } from './PhysicalExamSummary.js';
 export { PriceInput, type PriceInputProps } from './PriceInput.js';
 export {
   ServiceFormDialog,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,7 @@ export { ConsultationForm } from './ConsultationForm.js';
 export { MedicationList } from './MedicationList.js';
 export { MedicationFormList } from './MedicationFormList.js';
 export { VitalSignCard, type VitalSignCardProps } from './VitalSignCard.js';
+export { ExamSystemRow, type ExamSystemRowProps } from './ExamSystemRow.js';
 export { PhysicalExamSummary, type PhysicalExamSummaryProps } from './PhysicalExamSummary.js';
 export { PriceInput, type PriceInputProps } from './PriceInput.js';
 export {

--- a/src/hooks/useConsultationsSettings.ts
+++ b/src/hooks/useConsultationsSettings.ts
@@ -11,6 +11,7 @@ export interface ConsultationsSettings {
   defaultVet: string;
   showPrices: boolean;
   prefillVitals: boolean;
+  structuredExam: boolean;
 }
 
 const DEFAULTS: Record<string, unknown> = {
@@ -18,6 +19,7 @@ const DEFAULTS: Record<string, unknown> = {
   'consultations.defaultVet': '',
   'consultations.showPrices': true,
   'consultations.prefillVitals': true,
+  'consultations.structuredExam': true,
 };
 
 function parseSettings(raw: Record<string, unknown>): ConsultationsSettings {
@@ -28,6 +30,7 @@ function parseSettings(raw: Record<string, unknown>): ConsultationsSettings {
     defaultVet: (get('consultations.defaultVet') as string) || '',
     showPrices: get('consultations.showPrices') as boolean,
     prefillVitals: get('consultations.prefillVitals') as boolean,
+    structuredExam: get('consultations.structuredExam') as boolean,
   };
 }
 

--- a/src/hooks/useConsultationsSettings.ts
+++ b/src/hooks/useConsultationsSettings.ts
@@ -10,12 +10,14 @@ export interface ConsultationsSettings {
   reasonCategoriesEnabled: boolean;
   defaultVet: string;
   showPrices: boolean;
+  prefillVitals: boolean;
 }
 
 const DEFAULTS: Record<string, unknown> = {
   'consultations.reasonCategories': true,
   'consultations.defaultVet': '',
   'consultations.showPrices': true,
+  'consultations.prefillVitals': true,
 };
 
 function parseSettings(raw: Record<string, unknown>): ConsultationsSettings {
@@ -25,6 +27,7 @@ function parseSettings(raw: Record<string, unknown>): ConsultationsSettings {
     reasonCategoriesEnabled: get('consultations.reasonCategories') as boolean,
     defaultVet: (get('consultations.defaultVet') as string) || '',
     showPrices: get('consultations.showPrices') as boolean,
+    prefillVitals: get('consultations.prefillVitals') as boolean,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,11 @@ export { MedicationList } from './components/MedicationList.js';
 export { MedicationFormList } from './components/MedicationFormList.js';
 export { ConsultationStats } from './components/ConsultationStats.js';
 export { ServiceLineForm } from './components/ServiceLineForm.js';
+export { VitalSignCard, type VitalSignCardProps } from './components/VitalSignCard.js';
+export {
+  PhysicalExamSummary,
+  type PhysicalExamSummaryProps,
+} from './components/PhysicalExamSummary.js';
 export { PriceInput, type PriceInputProps } from './components/PriceInput.js';
 export {
   ServiceFormDialog,
@@ -39,7 +44,9 @@ export type {
   MedicationInput,
   ConsultationWithMedications,
   ReasonCategory,
+  PhysicalExamSystem,
 } from './types/consultation.js';
+export { EXAM_SYSTEMS } from './types/consultation.js';
 export type { ConsultationFilters, SortDirection } from './types/filters.js';
 export type {
   PetInfo,

--- a/src/schema/consultation.ts
+++ b/src/schema/consultation.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { jsonb, numeric, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { integer, jsonb, numeric, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 
 export const consultationTable = pgTable('module_consultations_consultations', {
   id: uuid('id').primaryKey().notNull(),
@@ -10,10 +10,14 @@ export const consultationTable = pgTable('module_consultations_consultations', {
     .default(sql`now()`),
   weight_kg: numeric('weight_kg'),
   temperature: numeric('temperature'),
+  heart_rate: integer('heart_rate'),
+  respiratory_rate: integer('respiratory_rate'),
+  body_condition_score: numeric('body_condition_score'),
   reason: text('reason').notNull(),
   reason_category: text('reason_category'),
   anamnesis: text('anamnesis'),
   physical_exam: text('physical_exam'),
+  physical_exam_systems: jsonb('physical_exam_systems'),
   diagnosis: text('diagnosis'),
   diagnosis_tags: jsonb('diagnosis_tags'),
   treatment: text('treatment'),

--- a/src/types/consultation.ts
+++ b/src/types/consultation.ts
@@ -25,6 +25,22 @@ export const EXAM_SYSTEMS = [
   'Urogenital',
 ] as const;
 
+/** Ejemplos contextuales de hallazgos por sistema, usados como placeholder en ExamSystemRow */
+export const EXAM_SYSTEM_EXAMPLES: Record<string, string> = {
+  'Apariencia general': 'Ej: Alerta, buen estado corporal',
+  Ojos: 'Ej: Secreción ocular, conjuntivitis',
+  Oídos: 'Ej: Otitis, cerumen excesivo',
+  'Cavidad oral': 'Ej: Sarro grado II, gingivitis',
+  'Ganglios linfáticos': 'Ej: Submandibulares reactivos',
+  Cardiovascular: 'Ej: Soplo grado III/VI, arritmia',
+  Respiratorio: 'Ej: Crepitaciones, disnea leve',
+  Abdominal: 'Ej: Dolor a la palpación, distensión',
+  Musculoesquelético: 'Ej: Claudicación MPD, dolor lumbar',
+  Neurológico: 'Ej: Ataxia, déficit propioceptivo',
+  'Piel / Tegumento': 'Ej: Alopecia focal, dermatitis',
+  Urogenital: 'Ej: Criptorquidia, secreción vulvar',
+};
+
 export interface Consultation {
   id: string;
   pet_id: string;

--- a/src/types/consultation.ts
+++ b/src/types/consultation.ts
@@ -4,6 +4,27 @@
 
 export type ReasonCategory = 'routine' | 'vaccination' | 'illness' | 'surgery' | 'emergency';
 
+export interface PhysicalExamSystem {
+  system: string;
+  status: 'WNL' | 'ABN';
+  notes: string;
+}
+
+export const EXAM_SYSTEMS = [
+  'Apariencia general',
+  'Ojos',
+  'Oídos',
+  'Cavidad oral',
+  'Ganglios linfáticos',
+  'Cardiovascular',
+  'Respiratorio',
+  'Abdominal',
+  'Musculoesquelético',
+  'Neurológico',
+  'Piel / Tegumento',
+  'Urogenital',
+] as const;
+
 export interface Consultation {
   id: string;
   pet_id: string;
@@ -11,10 +32,14 @@ export interface Consultation {
   date: string;
   weight_kg: string | null;
   temperature: string | null;
+  heart_rate: number | null;
+  respiratory_rate: number | null;
+  body_condition_score: string | null;
   reason: string;
   reason_category: string | null;
   anamnesis: string | null;
   physical_exam: string | null;
+  physical_exam_systems: PhysicalExamSystem[] | null;
   diagnosis: string | null;
   diagnosis_tags: string[] | null;
   treatment: string | null;
@@ -48,10 +73,14 @@ export interface ConsultationCreateData {
   date?: string;
   weight_kg?: string | null;
   temperature?: string | null;
+  heart_rate?: number | null;
+  respiratory_rate?: number | null;
+  body_condition_score?: string | null;
   reason: string;
   reason_category?: string | null;
   anamnesis?: string | null;
   physical_exam?: string | null;
+  physical_exam_systems?: PhysicalExamSystem[] | null;
   diagnosis?: string | null;
   diagnosis_tags?: string[] | null;
   treatment?: string | null;
@@ -67,10 +96,14 @@ export interface ConsultationUpdateData {
   date?: string;
   weight_kg?: string | null;
   temperature?: string | null;
+  heart_rate?: number | null;
+  respiratory_rate?: number | null;
+  body_condition_score?: string | null;
   reason?: string;
   reason_category?: string | null;
   anamnesis?: string | null;
   physical_exam?: string | null;
+  physical_exam_systems?: PhysicalExamSystem[] | null;
   diagnosis?: string | null;
   diagnosis_tags?: string[] | null;
   treatment?: string | null;


### PR DESCRIPTION
Closes #40

## Changes
- Add PetPicker to consultation form when no patient is pre-selected (reduces clicks)
- Add heart rate (FC), respiratory rate (FR), and body condition score (BCS) to vital signs
- Add structured physical exam by body systems with WNL/ABN checklist
- Reorder form sections to follow clinical SOAP flow (S → O → A → P)
- Auto-fill vital signs from patient's last consultation (configurable via settings)
- Add contextual placeholder examples per body system
- Add `prefillVitals` and `structuredExam` settings under Consultas > General > Formulario
- Export medication constants via `./constants/medication` subpath for vet-pharmacy
- New reusable components: VitalSignCard, PhysicalExamSummary, ExamSystemRow, ExamSystemList
- Responsive ExamSystemList with compact mode for mobile (<450px)
- Migration 0003: adds heart_rate, respiratory_rate, body_condition_score, physical_exam_systems columns
- Update ConsultationDetail to display new vital signs and exam systems

## Testing
- Create a new consultation — verify all SOAP sections render in correct order
- Verify PetPicker appears when opening form without a pre-selected patient
- Toggle WNL/ABN on exam systems — ABN rows should highlight red with note input
- Check vital signs auto-fill: create a 2nd consultation for same patient
- Disable `prefillVitals` in settings — verify vitals are blank on new consultation
- Disable `structuredExam` in settings — verify textarea replaces checklist
- Check responsive: resize modal to <450px, verify compact mode activates
- View consultation detail — verify FC, FR, BCS appear in sidebar vitals card
- View consultation detail — verify exam systems section with badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)