### PR TITLE
chore: Adopt core Avatar fix — use UI.Avatar with icon prop

### DIFF
--- a/src/components/ConsultationCard.tsx
+++ b/src/components/ConsultationCard.tsx
@@ -8,7 +8,7 @@ import {
   formatConsultationDate,
   formatReasonCategory,
   getReasonCategoryBadgeVariant,
-  getReasonCategoryEmoji,
+  getReasonCategoryIcon,
 } from '../utils/labels.js';
 import { formatCurrency } from '../utils/price.js';
 
@@ -18,7 +18,7 @@ const UI = getHostUI();
 export function ConsultationCard(props: ConsultationCardProps) {
   const { consultation: c, amount, onClick, actions: cardActions, className = '' } = props;
 
-  const emoji = getReasonCategoryEmoji(c.reason_category);
+  const categoryIcon = getReasonCategoryIcon(c.reason_category);
   const badgeVariant = getReasonCategoryBadgeVariant(c.reason_category);
   const categoryLabel = formatReasonCategory(c.reason_category);
   const dateStr = formatConsultationDate(c.date);
@@ -33,8 +33,12 @@ export function ConsultationCard(props: ConsultationCardProps) {
       'div',
       { className: 'flex items-start gap-3' },
 
-      // Emoji/icono
-      React.createElement('span', { className: 'text-lg flex-shrink-0 mt-0.5' }, emoji),
+      // Icono de categoría
+      React.createElement(UI.DynamicIcon, {
+        icon: categoryIcon,
+        size: 18,
+        className: 'flex-shrink-0 mt-0.5 text-cg-text-muted',
+      }),
 
       // Contenido
       React.createElement(
@@ -77,20 +81,23 @@ export function ConsultationCard(props: ConsultationCardProps) {
           c.weight_kg &&
             React.createElement(
               'span',
-              { className: 'text-xs text-cg-text-muted' },
-              `⚖️ ${c.weight_kg} kg`
+              { className: 'inline-flex items-center gap-1 text-xs text-cg-text-muted' },
+              React.createElement(UI.DynamicIcon, { icon: 'Scale', size: 12 }),
+              `${c.weight_kg} kg`
             ),
           c.temperature &&
             React.createElement(
               'span',
-              { className: 'text-xs text-cg-text-muted' },
-              `🌡️ ${c.temperature}°C`
+              { className: 'inline-flex items-center gap-1 text-xs text-cg-text-muted' },
+              React.createElement(UI.DynamicIcon, { icon: 'Thermometer', size: 12 }),
+              `${c.temperature}°C`
             ),
           c.follow_up_date &&
             React.createElement(
               'span',
-              { className: 'text-xs text-cg-text-muted' },
-              `📅 Control: ${formatConsultationDate(c.follow_up_date)}`
+              { className: 'inline-flex items-center gap-1 text-xs text-cg-text-muted' },
+              React.createElement(UI.DynamicIcon, { icon: 'Calendar', size: 12 }),
+              `Control: ${formatConsultationDate(c.follow_up_date)}`
             ),
           amount !== null &&
             amount !== undefined &&

--- a/src/components/ConsultationDetail.tsx
+++ b/src/components/ConsultationDetail.tsx
@@ -34,10 +34,10 @@ const SECTION_ICONS: Record<string, string> = {
   Notas: 'FileText',
 };
 
-const SPECIES_EMOJI: Record<string, string> = {
-  dog: '🐕',
-  cat: '🐈',
-  other: '🐾',
+const SPECIES_ICON: Record<string, string> = {
+  dog: 'Dog',
+  cat: 'Cat',
+  other: 'PawPrint',
 };
 
 const SEX_LABELS: Record<string, string> = {
@@ -174,7 +174,7 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
   );
 
   // Info de mascota para el header
-  const petEmoji = pet ? (SPECIES_EMOJI[pet.species] ?? '🐾') : '🐾';
+  const petIcon = pet ? (SPECIES_ICON[pet.species] ?? 'PawPrint') : 'PawPrint';
   const petName = pet?.name ?? 'Paciente';
   const petDetails = [
     pet?.breed,
@@ -243,7 +243,12 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
             { className: 'flex items-center gap-4' },
             React.createElement(UI.Avatar, {
               size: 'lg',
-              icon: React.createElement('span', { className: 'text-2xl' }, petEmoji),
+              icon: React.createElement(UI.DynamicIcon, {
+                icon: petIcon,
+                size: 28,
+                className: 'text-cg-text-muted',
+              }),
+              className: 'bg-cg-bg-tertiary',
             }),
             React.createElement(
               'div',

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,12 +75,12 @@ export { formatPrice, formatCurrency, sanitizePrice, isValidPrice } from './util
 export { createCategoryMap } from './utils/categories.js';
 export {
   REASON_CATEGORY_LABELS,
-  REASON_CATEGORY_EMOJI,
+  REASON_CATEGORY_ICON,
   REASON_CATEGORY_BADGE_VARIANTS,
   ALL_REASON_CATEGORIES,
   formatReasonCategory,
   getReasonCategoryBadgeVariant,
-  getReasonCategoryEmoji,
+  getReasonCategoryIcon,
   formatConsultationDate,
   formatConsultationDateTime,
 } from './utils/labels.js';

--- a/src/utils/labels.ts
+++ b/src/utils/labels.ts
@@ -8,12 +8,13 @@ export const REASON_CATEGORY_LABELS: Record<ReasonCategory, string> = {
   emergency: 'Emergencia',
 };
 
-export const REASON_CATEGORY_EMOJI: Record<ReasonCategory, string> = {
-  routine: '🔵',
-  vaccination: '💉',
-  illness: '🤒',
-  surgery: '🔪',
-  emergency: '🚨',
+/** Mapeo categoría → nombre de icono Lucide */
+export const REASON_CATEGORY_ICON: Record<ReasonCategory, string> = {
+  routine: 'CalendarCheck',
+  vaccination: 'Syringe',
+  illness: 'Thermometer',
+  surgery: 'Scissors',
+  emergency: 'Siren',
 };
 
 export const REASON_CATEGORY_BADGE_VARIANTS: Record<ReasonCategory, string> = {
@@ -42,9 +43,9 @@ export function getReasonCategoryBadgeVariant(category: string | null): string {
   return REASON_CATEGORY_BADGE_VARIANTS[category as ReasonCategory] ?? 'secondary';
 }
 
-export function getReasonCategoryEmoji(category: string | null): string {
-  if (!category) return '📋';
-  return REASON_CATEGORY_EMOJI[category as ReasonCategory] ?? '📋';
+export function getReasonCategoryIcon(category: string | null): string {
+  if (!category) return 'ClipboardList';
+  return REASON_CATEGORY_ICON[category as ReasonCategory] ?? 'ClipboardList';
 }
 
 export function formatConsultationDate(dateStr: string): string {

--- a/src/views/consultations-list/index.tsx
+++ b/src/views/consultations-list/index.tsx
@@ -21,11 +21,11 @@ const React = getHostReact();
 const UI = getHostUI();
 const { useState, useCallback, useEffect, useRef } = React;
 
-// Emojis por especie (mismo map que patients)
-const SPECIES_EMOJI: Record<string, string> = {
-  dog: '🐕',
-  cat: '🐈',
-  other: '🐾',
+// Iconos Lucide por especie (coherente con patients)
+const SPECIES_ICON: Record<string, string> = {
+  dog: 'Dog',
+  cat: 'Cat',
+  other: 'PawPrint',
 };
 
 interface PetInfo {
@@ -196,7 +196,7 @@ export function ConsultationsListView() {
   /** Renderiza una fila de consulta con datos de mascota resueltos */
   function renderConsultationRow(c: Consultation) {
     const pet = petMap.get(c.pet_id);
-    const petEmoji = pet ? (SPECIES_EMOJI[pet.species] ?? '🐾') : '🐾';
+    const petIcon = pet ? (SPECIES_ICON[pet.species] ?? 'PawPrint') : 'PawPrint';
     const petName = pet ? pet.name : '…';
 
     return React.createElement(
@@ -217,7 +217,7 @@ export function ConsultationsListView() {
         React.createElement(
           'div',
           { className: 'flex items-center gap-2' },
-          React.createElement('span', null, petEmoji),
+          React.createElement(UI.DynamicIcon, { icon: petIcon, size: 16 }),
           React.createElement('span', { className: 'font-medium' }, petName)
         )
       ),


### PR DESCRIPTION
Closes #45

## Changes
- Replace manual `<div>` Avatar workaround with `UI.Avatar` + `icon` prop in ConsultationDetail (core Coongro/Coongro#361)
- Replace emoji indicators with DynamicIcon + Lucide icons
- Update labels with icon mappings

## Testing
- ConsultationDetail: pet species icon visible (not white) on tertiary background

🤖 Generated with [Claude Code](https://claude.com/claude-code)