### PR TITLE
feat: Integrate @coongro/calendar for follow-up scheduling

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@coongro/calendar": ">=0.1.0",
     "@coongro/patients": ">=0.1.0",
     "@coongro/products": ">=0.1.0"
   },

--- a/src/components/ConsultationCard.tsx
+++ b/src/components/ConsultationCard.tsx
@@ -1,6 +1,7 @@
 /**
  * Card resumida de una consulta. Usada en el timeline y en listados.
  */
+import { formatEventDate } from '@coongro/calendar';
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
 import type { ConsultationCardProps } from '../types/components.js';
@@ -97,7 +98,7 @@ export function ConsultationCard(props: ConsultationCardProps) {
               'span',
               { className: 'inline-flex items-center gap-1 text-xs text-cg-text-muted' },
               React.createElement(UI.DynamicIcon, { icon: 'Calendar', size: 12 }),
-              `Control: ${formatConsultationDate(c.follow_up_date)}`
+              `Control: ${formatEventDate(c.follow_up_date)}`
             ),
           amount !== null &&
             amount !== undefined &&

--- a/src/components/ConsultationDetail.tsx
+++ b/src/components/ConsultationDetail.tsx
@@ -3,6 +3,8 @@
  * Encabezado con info de mascota, panel lateral sticky (vet, vitales, seguimiento),
  * y contenido clínico principal.
  */
+import { useEventsByEntity, formatEventDate, EventCard } from '@coongro/calendar';
+import type { CalendarEvent } from '@coongro/calendar';
 import { getHostReact, getHostUI, useViewContributions, actions } from '@coongro/plugin-sdk';
 
 import { useConsultation } from '../hooks/useConsultation.js';
@@ -97,6 +99,10 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
   }, [consultation?.pet_id, petProp]);
 
   const pet = petProp ?? fetchedPet;
+
+  // Evento de seguimiento vinculado a esta consulta
+  const { data: calendarEvents } = useEventsByEntity(consultationId, 'consultation');
+  const followUpEvent: CalendarEvent | undefined = calendarEvents?.[0];
 
   // Contribuciones de otros plugins para la zona de medicamentos
   const { sections: medContributions } = useViewContributions('consultations.detail.open', {
@@ -374,8 +380,35 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
             )
           ),
 
-        // Próximo control
-        c.follow_up_date &&
+        // Próximo control (desde evento del calendario)
+        followUpEvent &&
+          React.createElement(
+            UI.Card,
+            { className: 'p-3 border-cg-warning-border bg-cg-warning-bg' },
+            React.createElement(
+              'div',
+              { className: 'flex items-center gap-2 mb-2' },
+              React.createElement(UI.DynamicIcon, {
+                icon: 'Calendar',
+                size: 16,
+                className: 'text-cg-warning-text',
+              }),
+              React.createElement(
+                'span',
+                { className: 'text-xs font-semibold uppercase tracking-wider text-cg-text-muted' },
+                'Próximo control'
+              )
+            ),
+            React.createElement(EventCard, {
+              event: followUpEvent,
+              showTime: true,
+              showStatus: true,
+            })
+          ),
+
+        // Fallback: follow_up_date sin evento de calendario (consultas previas a la integración)
+        !followUpEvent &&
+          c.follow_up_date &&
           React.createElement(
             UI.Card,
             { className: 'p-4 border-cg-warning-border bg-cg-warning-bg' },
@@ -396,12 +429,7 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
             React.createElement(
               'p',
               { className: 'text-sm font-medium text-cg-text' },
-              new Date(c.follow_up_date).toLocaleDateString('es-AR', {
-                weekday: 'long',
-                day: 'numeric',
-                month: 'long',
-                year: 'numeric',
-              })
+              formatEventDate(c.follow_up_date)
             )
           ),
 

--- a/src/hooks/useConsultationCalendarSync.ts
+++ b/src/hooks/useConsultationCalendarSync.ts
@@ -1,0 +1,83 @@
+/**
+ * Sincroniza consultas con eventos del calendario.
+ * Crea/actualiza eventos en @coongro/calendar cuando una consulta
+ * tiene follow_up_date definido.
+ */
+import type { EventCreateData, CalendarEvent } from '@coongro/calendar';
+import { actions } from '@coongro/plugin-sdk';
+
+import type { Consultation } from '../types/consultation.js';
+
+const ENTITY_TYPE = 'consultation';
+const DEFAULT_DURATION_MIN = 30;
+const DEFAULT_TIME = '09:00';
+
+function buildFollowUpEvent(consultation: Consultation, petName: string): EventCreateData {
+  const dateStr = consultation.follow_up_date;
+  const startAt = new Date(`${dateStr}T${DEFAULT_TIME}:00`);
+  const endAt = new Date(startAt.getTime() + DEFAULT_DURATION_MIN * 60 * 1000);
+
+  return {
+    title: `Seguimiento: ${petName}`,
+    description: consultation.reason,
+    start_at: startAt.toISOString(),
+    end_at: endAt.toISOString(),
+    status: 'scheduled',
+    entity_id: consultation.id,
+    entity_type: ENTITY_TYPE,
+    notes: consultation.follow_up_notes ?? consultation.notes ?? undefined,
+    metadata: {
+      pet_id: consultation.pet_id,
+      consultation_id: consultation.id,
+      reason: consultation.reason,
+    },
+  };
+}
+
+/**
+ * Crea o actualiza un evento de seguimiento en el calendario.
+ * Si ya existe un evento vinculado a esta consulta, lo actualiza.
+ */
+export async function syncFollowUpEvent(
+  consultation: Consultation,
+  petName: string
+): Promise<CalendarEvent | null> {
+  if (!consultation.follow_up_date) return null;
+
+  const existing = await actions.execute<CalendarEvent[]>('calendar.events.listByEntity', {
+    entityId: consultation.id,
+    entityType: ENTITY_TYPE,
+  });
+
+  const eventData = buildFollowUpEvent(consultation, petName);
+  const existingEvent = existing?.[0];
+
+  if (existingEvent) {
+    const result = await actions.execute<CalendarEvent[]>('calendar.events.update', {
+      id: existingEvent.id,
+      data: eventData,
+    });
+    return result?.[0] ?? null;
+  }
+
+  const result = await actions.execute<CalendarEvent[]>('calendar.events.create', {
+    data: eventData,
+  });
+  return result?.[0] ?? null;
+}
+
+/**
+ * Elimina eventos de seguimiento vinculados a una consulta.
+ */
+export async function removeFollowUpEvent(consultationId: string): Promise<void> {
+  const existing = await actions.execute<CalendarEvent[]>('calendar.events.listByEntity', {
+    entityId: consultationId,
+    entityType: ENTITY_TYPE,
+  });
+
+  if (existing?.length) {
+    await Promise.all(
+      existing.map((e) => actions.execute('calendar.events.softDelete', { id: e.id }))
+    );
+  }
+}

--- a/src/hooks/useConsultationMutations.ts
+++ b/src/hooks/useConsultationMutations.ts
@@ -10,8 +10,17 @@ import type {
   ConsultationUpdateData,
 } from '../types/consultation.js';
 
+import { syncFollowUpEvent, removeFollowUpEvent } from './useConsultationCalendarSync.js';
+
 const React = getHostReact();
 const { useState, useCallback } = React;
+
+async function resolvePetName(petId: string): Promise<string> {
+  const pet = await actions.execute<{ name: string } | undefined>('patients.pets.getById', {
+    id: petId,
+  });
+  return pet?.name ?? 'Paciente';
+}
 
 export interface UseConsultationMutationsResult {
   creating: boolean;
@@ -75,6 +84,12 @@ export function useConsultationMutations(): UseConsultationMutationsResult {
 
         if (promises.length > 0) await Promise.all(promises);
 
+        // Sincronizar evento de seguimiento en calendario
+        if (consultation.follow_up_date) {
+          const petName = await resolvePetName(consultation.pet_id);
+          await syncFollowUpEvent(consultation, petName);
+        }
+
         toast.success('Consulta registrada', data.reason);
         return consultation;
       } catch (err) {
@@ -124,8 +139,19 @@ export function useConsultationMutations(): UseConsultationMutationsResult {
           }
         }
 
+        // Sincronizar o eliminar evento de seguimiento
+        const updated = result[0];
+        if (updated) {
+          if (updated.follow_up_date) {
+            const petName = await resolvePetName(updated.pet_id);
+            await syncFollowUpEvent(updated, petName);
+          } else {
+            await removeFollowUpEvent(id);
+          }
+        }
+
         toast.success('Consulta actualizada', '');
-        return result[0] ?? null;
+        return updated ?? null;
       } catch (err) {
         toast.error(
           'Error',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,9 @@
       "@coongro/contacts": [
         "../contacts/dist/index.d.ts"
       ],
+      "@coongro/calendar": [
+        "../calendar/dist/index.d.ts"
+      ],
       "@coongro/products": [
         "../products/dist/index.d.ts"
       ],


### PR DESCRIPTION
## Summary
- Sync `follow_up_date` to calendar events when creating/editing consultations
- Display follow-up events using `EventCard` from calendar plugin in consultation detail view
- Use `formatEventDate` from calendar for date formatting in consultation cards
- Fallback to static display for consultations created before this integration

## Dependencies
- Requires Coongro/calendar#17 merged first (`DatePicker` export + inline styles fix)

## Test plan
- [ ] Create consultation with follow_up_date → verify calendar event is created
- [ ] Edit consultation, change follow_up_date → verify calendar event is updated
- [ ] Edit consultation, remove follow_up_date → verify calendar event is soft-deleted
- [ ] Open consultation detail → verify "Próximo control" shows EventCard with time and status
- [ ] Verify old consultations (without calendar events) still show follow_up_date correctly

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)