### PR TITLE
feat: use calendar DatePicker/DateTimePicker + fix duplicate toast

### DIFF
--- a/.changeset/use-calendar-datepicker.md
+++ b/.changeset/use-calendar-datepicker.md
@@ -1,0 +1,5 @@
+---
+"@coongro/consultations": minor
+---
+
+Use calendar DatePicker/DateTimePicker instead of native inputs, fix duplicate toast on edit

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "consultations",
-  "version": "0.3.0",
+  "version": "0.5.1",
   "apiVersion": "2.0",
   "entry": "dist/entry.js",
   "assets": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coongro/consultations",
-  "version": "0.3.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "Bloque de historia clinica: consultas veterinarias, diagnosticos y tratamientos",
   "main": "dist/index.js",

--- a/src/components/ConsultationDetail.tsx
+++ b/src/components/ConsultationDetail.tsx
@@ -401,6 +401,7 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
             ),
             React.createElement(EventCard, {
               event: followUpEvent,
+              showDate: true,
               showTime: true,
               showStatus: true,
             })

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -9,6 +9,7 @@
  *   6. P — Tratamiento + Medicamentos + Seguimiento
  *   7. Servicios prestados (facturación)
  */
+import { DatePicker, DateTimePicker } from '@coongro/calendar';
 import { PetPicker } from '@coongro/patients';
 import type { Pet } from '@coongro/patients';
 import {
@@ -416,10 +417,10 @@ export function ConsultationForm(props: ConsultationFormProps) {
             'div',
             { className: FIELD_GAP },
             React.createElement(UI.Label, null, 'Fecha y hora'),
-            React.createElement(UI.Input, {
-              type: 'datetime-local',
+            React.createElement(DateTimePicker, {
               value: date,
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) => setDate(e.target.value),
+              onChange: (datetime: string) => setDate(datetime),
+              step: 30,
             })
           )
         )
@@ -650,10 +651,11 @@ export function ConsultationForm(props: ConsultationFormProps) {
             'div',
             { className: FIELD_GAP },
             React.createElement(UI.Label, null, 'Próximo control'),
-            React.createElement(UI.Input, {
-              type: 'date',
+            React.createElement(DatePicker, {
               value: followUpDate,
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) => setFollowUpDate(e.target.value),
+              onChange: (date: string) => setFollowUpDate(date),
+              placeholder: 'Seleccionar fecha',
+              minDate: new Date().toISOString().split('T')[0],
             })
           ),
           React.createElement(

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -419,7 +419,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
             React.createElement(UI.Label, null, 'Fecha y hora'),
             React.createElement(DateTimePicker, {
               value: date,
-              onChange: (datetime: string) => setDate(datetime),
+              onChange: setDate,
               step: 30,
             })
           )
@@ -653,7 +653,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
             React.createElement(UI.Label, null, 'Próximo control'),
             React.createElement(DatePicker, {
               value: followUpDate,
-              onChange: (date: string) => setFollowUpDate(date),
+              onChange: setFollowUpDate,
               placeholder: 'Seleccionar fecha',
               minDate: new Date().toISOString().split('T')[0],
             })

--- a/src/views/consultation-detail/index.tsx
+++ b/src/views/consultation-detail/index.tsx
@@ -13,7 +13,7 @@ const UI = getHostUI();
 const { useState, useCallback } = React;
 
 export function ConsultationDetailView(props: { consultationId?: string }) {
-  const { views, toast } = usePlugin();
+  const { views } = usePlugin();
   const consultationId =
     props.consultationId ?? (views.params as Record<string, string>)?.consultationId;
 
@@ -32,8 +32,7 @@ export function ConsultationDetailView(props: { consultationId?: string }) {
   const handleEditSuccess = useCallback(() => {
     setShowEditModal(false);
     setRefreshKey((k: number) => k + 1);
-    toast.success('Consulta actualizada', 'Los cambios se guardaron correctamente');
-  }, [toast]);
+  }, []);
 
   const handleDelete = useCallback(
     (c: Consultation) => {

--- a/src/views/consultations-list/index.tsx
+++ b/src/views/consultations-list/index.tsx
@@ -2,6 +2,7 @@
  * Vista principal: historial de consultas con stats, filtros inline y tabla.
  * Usa DataTable de ui-components para renderizado desktop + cards en móvil.
  */
+import { DatePicker } from '@coongro/calendar';
 import { getHostReact, getHostUI, usePlugin, actions } from '@coongro/plugin-sdk';
 
 import { ConsultationStats } from '../../components/ConsultationStats.js';
@@ -135,15 +136,15 @@ export function ConsultationsListView() {
   );
 
   const handleDateFrom = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setFilters({ ...filters, dateFrom: e.target.value || undefined });
+    (date: string) => {
+      setFilters({ ...filters, dateFrom: date || undefined });
     },
     [filters, setFilters]
   );
 
   const handleDateTo = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setFilters({ ...filters, dateTo: e.target.value || undefined });
+    (date: string) => {
+      setFilters({ ...filters, dateTo: date || undefined });
     },
     [filters, setFilters]
   );
@@ -270,10 +271,11 @@ export function ConsultationsListView() {
             { className: 'text-xs font-medium text-cg-text-muted' },
             'Desde'
           ),
-          React.createElement(UI.Input, {
-            type: 'date',
+          React.createElement(DatePicker, {
             value: filters.dateFrom ?? '',
             onChange: handleDateFrom,
+            placeholder: 'Desde',
+            maxDate: filters.dateTo,
             className: 'w-40',
           })
         ),
@@ -286,10 +288,11 @@ export function ConsultationsListView() {
             { className: 'text-xs font-medium text-cg-text-muted' },
             'Hasta'
           ),
-          React.createElement(UI.Input, {
-            type: 'date',
+          React.createElement(DatePicker, {
             value: filters.dateTo ?? '',
             onChange: handleDateTo,
+            placeholder: 'Hasta',
+            minDate: filters.dateFrom,
             className: 'w-40',
           })
         )


### PR DESCRIPTION
Work item: COONG-76

## Changes
- Migrate date filters (Desde/Hasta) from native `<input type="date">` to DatePicker from @coongro/calendar
- Migrate ConsultationForm datetime from native `<input type="datetime-local">` to DateTimePicker
- Remove hardcoded minTime/maxTime — defaults come from calendar settings
- Show date in follow-up EventCard via new showDate prop
- Fix duplicate toast notification on consultation edit

## Testing
- [x] `npm run build` passes
- [x] `npm run quality` passes (warnings only)
- [ ] Verify DatePicker in consultation list filters (Desde/Hasta)
- [ ] Verify DateTimePicker in new consultation form (Fecha y hora)
- [ ] Verify DatePicker in follow-up date (Próximo control)
- [ ] Verify no duplicate toast when editing a consultation
- [ ] Verify follow-up card shows date in consultation detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)