### PR TITLE
feat: migrate vet_name to staff_id with StaffPicker + follow-up appointments

### DIFF
--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -82,6 +82,14 @@
     "settings": {
       "sections": [
         {
+          "id": "consultations.general.vet",
+          "page": "consultations.general",
+          "label": "Veterinario",
+          "order": 5,
+          "component": "./dist/index.js",
+          "export": "DefaultVetSetting"
+        },
+        {
           "id": "consultations.general.main",
           "page": "consultations.general",
           "label": "General",
@@ -98,19 +106,6 @@
                 "reasoncategories",
                 "categorías",
                 "motivo"
-              ]
-            },
-            {
-              "key": "consultations.defaultVet",
-              "type": "string",
-              "label": "Veterinario predeterminado",
-              "description": "Nombre del veterinario que se preselecciona al crear consultas",
-              "default": "",
-              "tags": [
-                "consultations",
-                "defaultvet",
-                "veterinario",
-                "predeterminado"
               ]
             },
             {

--- a/drizzle/0004_add_staff_id.sql
+++ b/drizzle/0004_add_staff_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "module_consultations_consultations"
+  ADD COLUMN IF NOT EXISTS "staff_id" text DEFAULT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1774944000000,
       "tag": "0003_vital_signs_and_physical_exam",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1744502400000,
+      "tag": "0004_add_staff_id",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -49,9 +49,11 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@coongro/appointments": ">=0.1.0",
     "@coongro/calendar": ">=0.1.0",
     "@coongro/patients": ">=0.1.0",
-    "@coongro/products": ">=0.1.0"
+    "@coongro/products": ">=0.1.0",
+    "@coongro/staff": ">=0.1.0"
   },
   "peerDependencies": {
     "@coongro/plugin-sdk": ">=0.13.0"

--- a/src/components/ConsultationDetail.tsx
+++ b/src/components/ConsultationDetail.tsx
@@ -6,6 +6,7 @@
 import { useEventsByEntity, formatEventDate, EventCard } from '@coongro/calendar';
 import type { CalendarEvent } from '@coongro/calendar';
 import { getHostReact, getHostUI, useViewContributions, actions } from '@coongro/plugin-sdk';
+import { StaffBadge } from '@coongro/staff';
 
 import { useConsultation } from '../hooks/useConsultation.js';
 import { useConsultationsSettings } from '../hooks/useConsultationsSettings.js';
@@ -313,22 +314,24 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
           { className: 'p-4' },
           React.createElement(
             'div',
-            { className: 'flex items-center gap-3' },
-            React.createElement(UI.Avatar, { size: 'sm', name: c.vet_name }),
+            { className: 'flex flex-col gap-1' },
             React.createElement(
-              'div',
-              null,
-              React.createElement(
-                'span',
-                { className: 'text-xs text-cg-text-muted uppercase tracking-wider block' },
-                'Veterinario/a'
-              ),
-              React.createElement(
-                'span',
-                { className: 'text-sm font-medium text-cg-text' },
-                `Dr(a). ${c.vet_name}`
-              )
-            )
+              'span',
+              { className: 'text-xs text-cg-text-muted uppercase tracking-wider block' },
+              'Veterinario/a'
+            ),
+            c.staff_id
+              ? React.createElement(StaffBadge, { staffId: c.staff_id, variant: 'default' })
+              : React.createElement(
+                  'div',
+                  { className: 'flex items-center gap-3' },
+                  React.createElement(UI.Avatar, { size: 'sm', name: c.vet_name }),
+                  React.createElement(
+                    'span',
+                    { className: 'text-sm font-medium text-cg-text' },
+                    `Dr(a). ${c.vet_name}`
+                  )
+                )
           )
         ),
 

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -9,7 +9,7 @@
  *   6. P — Tratamiento + Medicamentos + Seguimiento
  *   7. Servicios prestados (facturación)
  */
-import { DatePicker, DateTimePicker } from '@coongro/calendar';
+import { DatePicker, DateTimePicker, TimePicker } from '@coongro/calendar';
 import { PetPicker } from '@coongro/patients';
 import type { Pet } from '@coongro/patients';
 import {
@@ -18,8 +18,11 @@ import {
   usePlugin,
   useViewContributions,
   actions,
+  settings,
 } from '@coongro/plugin-sdk';
 import type { Product, Category } from '@coongro/products';
+import { StaffPicker } from '@coongro/staff';
+import type { StaffMember } from '@coongro/staff';
 
 import { ROOT_SERVICE_CATEGORY_SLUG } from '../constants/services.js';
 import { useConsultation } from '../hooks/useConsultation.js';
@@ -33,6 +36,7 @@ import {
   type PhysicalExamSystem,
   type ServiceLineInput,
 } from '../types/consultation.js';
+import { parseFollowUpDate } from '../utils/follow-up.js';
 
 import { ExamSystemList } from './ExamSystemRow.js';
 import { MedicationFormList } from './MedicationFormList.js';
@@ -75,6 +79,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
 
   // --- Estado del formulario ---
   const [selectedPetId, setSelectedPetId] = useState(petId ?? defaults?.pet_id ?? '');
+  const [staffId, setStaffId] = useState<string | null>(defaults?.staff_id ?? null);
   const [vetName, setVetName] = useState(defaults?.vet_name ?? '');
   const [date, setDate] = useState(defaults?.date ?? new Date().toISOString().slice(0, 16));
 
@@ -93,7 +98,10 @@ export function ConsultationForm(props: ConsultationFormProps) {
   const [diagnosis, setDiagnosis] = useState(defaults?.diagnosis ?? '');
   const [treatment, setTreatment] = useState(defaults?.treatment ?? '');
   const [medications, setMedications] = useState<MedicationInput[]>(defaults?.medications ?? []);
-  const [followUpDate, setFollowUpDate] = useState(defaults?.follow_up_date ?? '');
+  const defaultFollowUp = parseFollowUpDate(defaults?.follow_up_date);
+  const [followUpDate, setFollowUpDate] = useState(defaultFollowUp.date);
+  const [followUpStartTime, setFollowUpStartTime] = useState(defaultFollowUp.startTime);
+  const [followUpEndTime, setFollowUpEndTime] = useState(defaultFollowUp.endTime);
   const [notes, setNotes] = useState(defaults?.notes ?? '');
 
   // Servicios
@@ -165,6 +173,11 @@ export function ConsultationForm(props: ConsultationFormProps) {
     if (pet?.weight_kg) setWeightKg(pet.weight_kg);
   }, []);
 
+  const handleStaffSelect = useCallback((member: StaffMember | null) => {
+    setStaffId(member?.id ?? null);
+    setVetName(member?.contact_name ?? '');
+  }, []);
+
   // Precargar signos vitales de la última consulta del paciente
   const vitalsLoadedRef = useRef(false);
   useEffect(() => {
@@ -203,16 +216,17 @@ export function ConsultationForm(props: ConsultationFormProps) {
     })();
   }, [selectedPetId, defaults?.pet_id, isEditing]);
 
-  // Cargar defaults del settings
+  // Preseleccionar el ultimo veterinario usado
   useEffect(() => {
-    if (!isEditing && consultSettings.defaultVet && !vetName) {
-      setVetName(consultSettings.defaultVet);
+    if (!isEditing && !staffId && consultSettings.defaultStaffId) {
+      setStaffId(consultSettings.defaultStaffId);
     }
-  }, [consultSettings.defaultVet, isEditing, vetName]);
+  }, [consultSettings.defaultStaffId, isEditing, staffId]);
 
   // Cargar datos existentes al editar
   useEffect(() => {
     if (!existing) return;
+    setStaffId(existing.staff_id ?? null);
     setVetName(existing.vet_name);
     setDate(existing.date.slice(0, 16));
     setWeightKg(existing.weight_kg ?? '');
@@ -228,7 +242,10 @@ export function ConsultationForm(props: ConsultationFormProps) {
     setPhysicalExamNotes(existing.physical_exam ?? '');
     setDiagnosis(existing.diagnosis ?? '');
     setTreatment(existing.treatment ?? '');
-    setFollowUpDate(existing.follow_up_date ?? '');
+    const parsed = parseFollowUpDate(existing.follow_up_date);
+    setFollowUpDate(parsed.date);
+    setFollowUpStartTime(parsed.startTime);
+    setFollowUpEndTime(parsed.endTime);
     setNotes(existing.notes ?? '');
     setSelectedPetId(existing.pet_id);
   }, [existing]);
@@ -285,8 +302,8 @@ export function ConsultationForm(props: ConsultationFormProps) {
         toast.error('Error', 'El motivo de consulta es obligatorio');
         return;
       }
-      if (!vetName.trim()) {
-        toast.error('Error', 'El nombre del veterinario es obligatorio');
+      if (!staffId && !vetName.trim()) {
+        toast.error('Error', 'Seleccioná un veterinario');
         return;
       }
 
@@ -299,6 +316,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
         : null;
 
       const sharedData = {
+        staff_id: staffId || null,
         vet_name: vetName.trim(),
         date: new Date(date).toISOString(),
         weight_kg: weightKg || null,
@@ -313,7 +331,9 @@ export function ConsultationForm(props: ConsultationFormProps) {
         physical_exam_systems: examData,
         diagnosis: diagnosis.trim() || null,
         treatment: treatment.trim() || null,
-        follow_up_date: followUpDate || null,
+        follow_up_date: followUpDate
+          ? `${followUpDate} ${followUpStartTime}-${followUpEndTime}`
+          : null,
         follow_up_notes: null,
         notes: notes.trim() || null,
       };
@@ -337,7 +357,13 @@ export function ConsultationForm(props: ConsultationFormProps) {
           medications: validMeds,
           services: validServices,
         });
-        if (result && onSuccess) onSuccess(result);
+        if (result && onSuccess) {
+          // Recordar el veterinario para la proxima consulta
+          if (staffId) {
+            void settings.set('consultations.defaultStaffId', staffId);
+          }
+          onSuccess(result);
+        }
       }
     },
     [
@@ -345,6 +371,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
       selectedPetId,
       defaults,
       isEditing,
+      staffId,
       vetName,
       date,
       weightKg,
@@ -359,6 +386,8 @@ export function ConsultationForm(props: ConsultationFormProps) {
       diagnosis,
       treatment,
       followUpDate,
+      followUpStartTime,
+      followUpEndTime,
       notes,
       medications,
       serviceLines,
@@ -405,12 +434,10 @@ export function ConsultationForm(props: ConsultationFormProps) {
             'div',
             { className: FIELD_GAP },
             React.createElement(UI.Label, null, 'Veterinario *'),
-            React.createElement(UI.Input, {
-              type: 'text',
-              value: vetName,
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) => setVetName(e.target.value),
-              placeholder: 'Nombre del veterinario',
-              required: true,
+            React.createElement(StaffPicker, {
+              value: staffId,
+              onChange: handleStaffSelect,
+              placeholder: 'Buscar veterinario...',
             })
           ),
           React.createElement(
@@ -646,7 +673,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
         React.createElement(SectionHeader, { icon: 'CalendarCheck', title: 'Seguimiento' }),
         React.createElement(
           'div',
-          { className: GRID_2 },
+          { className: 'grid grid-cols-4 gap-3' },
           React.createElement(
             'div',
             { className: FIELD_GAP },
@@ -656,6 +683,33 @@ export function ConsultationForm(props: ConsultationFormProps) {
               onChange: setFollowUpDate,
               placeholder: 'Seleccionar fecha',
               minDate: new Date().toISOString().split('T')[0],
+            })
+          ),
+          React.createElement(
+            'div',
+            { className: FIELD_GAP },
+            React.createElement(UI.Label, null, 'Inicio'),
+            React.createElement(TimePicker, {
+              value: followUpStartTime,
+              onChange: (t: string) => {
+                setFollowUpStartTime(t);
+                const [h, m] = t.split(':').map(Number);
+                const endMin = h * 60 + m + 30;
+                setFollowUpEndTime(
+                  `${String(Math.floor(endMin / 60) % 24).padStart(2, '0')}:${String(endMin % 60).padStart(2, '0')}`
+                );
+              },
+              step: 30,
+            })
+          ),
+          React.createElement(
+            'div',
+            { className: FIELD_GAP },
+            React.createElement(UI.Label, null, 'Fin'),
+            React.createElement(TimePicker, {
+              value: followUpEndTime,
+              onChange: setFollowUpEndTime,
+              step: 30,
             })
           ),
           React.createElement(

--- a/src/components/CreateConsultationButton.tsx
+++ b/src/components/CreateConsultationButton.tsx
@@ -22,6 +22,7 @@ const { useState, useCallback } = React;
 export function CreateConsultationButton(props: CreateConsultationButtonProps) {
   const {
     petId: petIdProp,
+    defaults,
     label = 'Nueva consulta',
     onSuccess,
     onCancel,
@@ -94,6 +95,7 @@ export function CreateConsultationButton(props: CreateConsultationButtonProps) {
         ? // Con petId: formulario directo
           React.createElement(ConsultationForm, {
             petId: petIdProp,
+            defaults,
             onSuccess: handleSuccess,
             onCancel: handleClose,
           })
@@ -114,6 +116,7 @@ export function CreateConsultationButton(props: CreateConsultationButtonProps) {
             selectedPetId
               ? React.createElement(ConsultationForm, {
                   petId: selectedPetId,
+                  defaults,
                   onSuccess: handleSuccess,
                   onCancel: handleClose,
                 })

--- a/src/components/DefaultVetSetting.tsx
+++ b/src/components/DefaultVetSetting.tsx
@@ -1,0 +1,115 @@
+/**
+ * Componente custom de settings para seleccionar el veterinario predeterminado.
+ * Se renderiza en la pagina de settings de Consultas como seccion custom.
+ */
+import { getHostReact, getHostUI, settings } from '@coongro/plugin-sdk';
+import { StaffPicker } from '@coongro/staff';
+import type { StaffMember } from '@coongro/staff';
+
+const React = getHostReact();
+const UI = getHostUI();
+const { useState, useEffect, useCallback, useRef } = React;
+
+const SETTING_KEY = 'consultations.defaultStaffId';
+
+/**
+ * Fuerza el ComboboxChipTrigger a una sola linea.
+ * El trigger usa flex-wrap que causa dos lineas cuando hay chip + input.
+ */
+function useCompactCombobox(containerRef: React.RefObject<HTMLDivElement>, hasValue: boolean) {
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const trigger = containerRef.current.querySelector<HTMLElement>('[role="combobox"]');
+    if (!trigger) return;
+
+    trigger.style.flexWrap = 'nowrap';
+    trigger.style.overflow = 'hidden';
+
+    const input = trigger.querySelector<HTMLInputElement>('input');
+    if (input) {
+      if (hasValue) {
+        input.style.width = '0';
+        input.style.minWidth = '0';
+        input.style.padding = '0';
+        input.style.opacity = '0';
+        input.style.position = 'absolute';
+      } else {
+        input.style.width = '';
+        input.style.minWidth = '';
+        input.style.padding = '';
+        input.style.opacity = '';
+        input.style.position = '';
+      }
+    }
+  }, [hasValue]);
+}
+
+export function DefaultVetSetting() {
+  const [staffId, setStaffId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  useCompactCombobox(pickerRef, !!staffId);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const value = await settings.get<string>(SETTING_KEY);
+        if (value) setStaffId(value);
+      } catch {
+        // Sin valor guardado
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleChange = useCallback((member: StaffMember | null) => {
+    const newId = member?.id ?? null;
+    setStaffId(newId);
+    void settings.set(SETTING_KEY, newId ?? '');
+  }, []);
+
+  if (loading) {
+    return React.createElement(UI.Skeleton, { className: 'h-10 w-full rounded-lg' });
+  }
+
+  return React.createElement(
+    'div',
+    {
+      style: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '16px',
+        borderRadius: '12px',
+        border: '1px solid var(--cg-border-subtle)',
+        background: 'var(--cg-surface)',
+        padding: '12px 16px',
+      },
+    },
+    React.createElement(
+      'div',
+      { style: { minWidth: 0, flex: 1 } },
+      React.createElement(
+        'label',
+        { style: { fontSize: '14px', fontWeight: 500, color: 'var(--cg-text)' } },
+        'Veterinario predeterminado'
+      ),
+      React.createElement(
+        'p',
+        { style: { fontSize: '12px', color: 'var(--cg-text-subtle)', marginTop: '2px' } },
+        'Se preselecciona al crear consultas nuevas'
+      )
+    ),
+    React.createElement(
+      'div',
+      { ref: pickerRef, style: { width: '220px', flexShrink: 0 } },
+      React.createElement(StaffPicker, {
+        value: staffId,
+        onChange: handleChange,
+        placeholder: 'Seleccionar...',
+      })
+    )
+  );
+}

--- a/src/hooks/useConsultationCalendarSync.ts
+++ b/src/hooks/useConsultationCalendarSync.ts
@@ -1,27 +1,36 @@
 /**
- * Sincroniza consultas con eventos del calendario.
- * Crea/actualiza eventos en @coongro/calendar cuando una consulta
- * tiene follow_up_date definido.
+ * Sincroniza consultas con eventos del calendario y turnos de seguimiento.
+ * Si @coongro/appointments esta disponible, crea un turno real.
+ * Si no, crea un evento de calendario como fallback.
  */
 import type { EventCreateData, CalendarEvent } from '@coongro/calendar';
 import { actions } from '@coongro/plugin-sdk';
 
 import type { Consultation } from '../types/consultation.js';
+import { parseFollowUpDate } from '../utils/follow-up.js';
 
 const ENTITY_TYPE = 'consultation';
 const DEFAULT_DURATION_MIN = 30;
-const DEFAULT_TIME = '09:00';
 
 function buildFollowUpEvent(consultation: Consultation, petName: string): EventCreateData {
-  const dateStr = consultation.follow_up_date;
-  const startAt = new Date(`${dateStr}T${DEFAULT_TIME}:00`);
-  const endAt = new Date(startAt.getTime() + DEFAULT_DURATION_MIN * 60 * 1000);
+  const { date, startTime, endTime } = parseFollowUpDate(consultation.follow_up_date);
+
+  const startIso = `${date}T${startTime}:00.000Z`;
+  // Si endTime difiere de startTime, usar esa hora; si no, calcular +30min
+  const hasExplicitEnd = endTime !== startTime;
+  let endIso: string;
+  if (hasExplicitEnd) {
+    endIso = `${date}T${endTime}:00.000Z`;
+  } else {
+    const endMs = new Date(startIso).getTime() + DEFAULT_DURATION_MIN * 60 * 1000;
+    endIso = new Date(endMs).toISOString();
+  }
 
   return {
     title: `Seguimiento: ${petName}`,
     description: consultation.reason,
-    start_at: startAt.toISOString(),
-    end_at: endAt.toISOString(),
+    start_at: startIso,
+    end_at: endIso,
     status: 'scheduled',
     entity_id: consultation.id,
     entity_type: ENTITY_TYPE,
@@ -34,9 +43,49 @@ function buildFollowUpEvent(consultation: Consultation, petName: string): EventC
   };
 }
 
+interface PetWithOwner {
+  name: string;
+  owner_id: string;
+}
+
+/**
+ * Intenta crear un appointment de seguimiento.
+ * Primero crea el calendar event, luego el appointment vinculado.
+ * Retorna true si se creo exitosamente.
+ */
+async function tryCreateFollowUpAppointment(
+  consultation: Consultation,
+  petName: string,
+  calendarEvent: CalendarEvent
+): Promise<boolean> {
+  try {
+    // Resolver owner_id del pet para el contact_id del appointment
+    const pet = await actions.execute<PetWithOwner | undefined>('patients.pets.getById', {
+      id: consultation.pet_id,
+    });
+    if (!pet?.owner_id) return false;
+
+    await actions.execute('appointments.create', {
+      data: {
+        contact_id: pet.owner_id,
+        pet_id: consultation.pet_id,
+        staff_id: consultation.staff_id ?? null,
+        reason: `Seguimiento: ${consultation.reason}`,
+        notes: consultation.follow_up_notes ?? null,
+        calendar_event_id: calendarEvent.id,
+        consultation_id: consultation.id,
+      },
+    });
+    return true;
+  } catch {
+    // appointments plugin no disponible o error — no es critico
+    return false;
+  }
+}
+
 /**
  * Crea o actualiza un evento de seguimiento en el calendario.
- * Si ya existe un evento vinculado a esta consulta, lo actualiza.
+ * Si appointments esta disponible, tambien crea un turno.
  */
 export async function syncFollowUpEvent(
   consultation: Consultation,
@@ -60,10 +109,17 @@ export async function syncFollowUpEvent(
     return result?.[0] ?? null;
   }
 
+  // Crear nuevo evento de calendario
   const result = await actions.execute<CalendarEvent[]>('calendar.events.create', {
     data: eventData,
   });
-  return result?.[0] ?? null;
+  const calendarEvent = result?.[0];
+  if (!calendarEvent) return null;
+
+  // Intentar crear appointment vinculado (fallback silencioso si no hay plugin)
+  await tryCreateFollowUpAppointment(consultation, petName, calendarEvent);
+
+  return calendarEvent;
 }
 
 /**

--- a/src/hooks/useConsultationsSettings.ts
+++ b/src/hooks/useConsultationsSettings.ts
@@ -8,7 +8,7 @@ const { useState, useEffect } = React;
 
 export interface ConsultationsSettings {
   reasonCategoriesEnabled: boolean;
-  defaultVet: string;
+  defaultStaffId: string;
   showPrices: boolean;
   prefillVitals: boolean;
   structuredExam: boolean;
@@ -16,7 +16,7 @@ export interface ConsultationsSettings {
 
 const DEFAULTS: Record<string, unknown> = {
   'consultations.reasonCategories': true,
-  'consultations.defaultVet': '',
+  'consultations.defaultStaffId': '',
   'consultations.showPrices': true,
   'consultations.prefillVitals': true,
   'consultations.structuredExam': true,
@@ -27,7 +27,7 @@ function parseSettings(raw: Record<string, unknown>): ConsultationsSettings {
 
   return {
     reasonCategoriesEnabled: get('consultations.reasonCategories') as boolean,
-    defaultVet: (get('consultations.defaultVet') as string) || '',
+    defaultStaffId: (get('consultations.defaultStaffId') as string) || '',
     showPrices: get('consultations.showPrices') as boolean,
     prefillVitals: get('consultations.prefillVitals') as boolean,
     structuredExam: get('consultations.structuredExam') as boolean,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { CreateConsultationButton } from './components/CreateConsultationButton.
 export { ConsultationTimeline } from './components/ConsultationTimeline.js';
 export { ConsultationDetail } from './components/ConsultationDetail.js';
 export { ConsultationForm } from './components/ConsultationForm.js';
+export { DefaultVetSetting } from './components/DefaultVetSetting.js';
 export { MedicationList } from './components/MedicationList.js';
 export { MedicationFormList } from './components/MedicationFormList.js';
 export { ConsultationStats } from './components/ConsultationStats.js';
@@ -42,6 +43,8 @@ export type {
   ConsultationCreateData,
   ConsultationUpdateData,
   MedicationInput,
+  ServiceLineInput,
+  ConsultationService,
   ConsultationWithMedications,
   ReasonCategory,
   PhysicalExamSystem,
@@ -59,6 +62,9 @@ export type {
   CreateConsultationButtonProps,
 } from './types/components.js';
 export type { ServiceLineFormProps } from './components/ServiceLineForm.js';
+
+// Constantes de servicios
+export { ROOT_SERVICE_CATEGORY_SLUG } from './constants/services.js';
 
 // Constantes de medicacion (exportables cross-plugin)
 export {

--- a/src/schema/consultation.ts
+++ b/src/schema/consultation.ts
@@ -5,6 +5,7 @@ export const consultationTable = pgTable('module_consultations_consultations', {
   id: uuid('id').primaryKey().notNull(),
   pet_id: text('pet_id').notNull(),
   vet_name: text('vet_name').notNull(),
+  staff_id: text('staff_id'),
   date: timestamp('date', { mode: 'string' })
     .notNull()
     .default(sql`now()`),

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -99,6 +99,8 @@ export interface ConsultationDetailProps {
 export interface CreateConsultationButtonProps {
   /** ID del paciente. Si se omite, muestra PetPicker para seleccionarlo. */
   petId?: string;
+  /** Valores por defecto para pre-llenar el formulario */
+  defaults?: Partial<ConsultationCreateData>;
   label?: string;
   onSuccess?: (consultation: Consultation) => void;
   onCancel?: () => void;

--- a/src/types/consultation.ts
+++ b/src/types/consultation.ts
@@ -45,6 +45,7 @@ export interface Consultation {
   id: string;
   pet_id: string;
   vet_name: string;
+  staff_id: string | null;
   date: string;
   weight_kg: string | null;
   temperature: string | null;
@@ -86,6 +87,7 @@ export interface ConsultationMedication {
 export interface ConsultationCreateData {
   pet_id: string;
   vet_name: string;
+  staff_id?: string | null;
   date?: string;
   weight_kg?: string | null;
   temperature?: string | null;
@@ -109,6 +111,7 @@ export interface ConsultationCreateData {
 
 export interface ConsultationUpdateData {
   vet_name?: string;
+  staff_id?: string | null;
   date?: string;
   weight_kg?: string | null;
   temperature?: string | null;

--- a/src/utils/follow-up.ts
+++ b/src/utils/follow-up.ts
@@ -1,0 +1,27 @@
+/**
+ * Parsea el campo follow_up_date que puede tener varios formatos:
+ *   "YYYY-MM-DD"
+ *   "YYYY-MM-DD HH:mm"
+ *   "YYYY-MM-DD HH:mm-HH:mm"
+ */
+
+const DEFAULT_START = '09:00';
+const DEFAULT_END = '09:30';
+
+export interface ParsedFollowUp {
+  date: string;
+  startTime: string;
+  endTime: string;
+}
+
+export function parseFollowUpDate(raw: string | null | undefined): ParsedFollowUp {
+  const dateStr = raw ?? '';
+  const date = dateStr.split(/[T ]/)[0];
+  const timePart = dateStr.split(/[T ]/)[1] ?? '';
+  const [startTime, endTime] = timePart.split('-');
+  return {
+    date,
+    startTime: startTime?.substring(0, 5) || DEFAULT_START,
+    endTime: endTime?.substring(0, 5) || DEFAULT_END,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,12 @@
       ],
       "@coongro/products/server": [
         "../products/dist/server.d.ts"
+      ],
+      "@coongro/staff": [
+        "../staff/dist/index.d.ts"
+      ],
+      "@coongro/appointments": [
+        "../appointments/dist/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
Work item: COONG-82

## Changes
- Add `staff_id` column to consultations table (migration 0004)
- Replace text input with StaffPicker from `@coongro/staff` in form
- Show StaffBadge in detail view (fallback to `vet_name` for old records)
- Follow-up now creates appointment via `@coongro/appointments` (with calendar event fallback)
- Add start/end TimePicker for follow-up scheduling
- Fix follow-up date timezone offset (off-by-one day)
- Add custom DefaultVetSetting with StaffPicker in settings page
- Auto-remember last used vet on consultation create
- Add `defaults` prop to CreateConsultationButton for pre-filling from appointments
- Export ServiceLineForm, ServiceLineInput, ROOT_SERVICE_CATEGORY_SLUG for cross-plugin use
- Extract `parseFollowUpDate` utility to eliminate duplication

## Testing
- [ ] `npm run build` passes
- [ ] Create consultation with StaffPicker — staff_id saved, vet_name derived
- [ ] View old consultation without staff_id — fallback to vet_name text
- [ ] Set follow-up date+time — calendar event created with correct range
- [ ] Follow-up creates appointment when @coongro/appointments is installed
- [ ] Settings > Consultas shows StaffPicker for default vet
- [ ] "Atender" from agenda pre-fills consultation form with staff, reason, services

🤖 Generated with [Claude Code](https://claude.com/claude-code)