### PR TITLE
fix: break circular dependency with @coongro/appointments

### DIFF
--- a/.changeset/break-appointments-circular-dep.md
+++ b/.changeset/break-appointments-circular-dep.md
@@ -1,0 +1,5 @@
+---
+'@coongro/consultations': patch
+---
+
+fix: remove `@coongro/appointments` from `dependencies` to break the circular package dependency. The runtime coupling (follow-up creates appointment) already uses the SDK action bus with a silent fallback, so the static dependency was unnecessary.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@coongro/appointments": ">=0.1.0",
     "@coongro/calendar": ">=0.1.0",
     "@coongro/patients": ">=0.1.0",
     "@coongro/products": ">=0.1.0",


### PR DESCRIPTION
Work item: COONG-95

## Summary
Remueve `@coongro/appointments` de las `dependencies` del `package.json` para romper el ciclo `appointments ↔ consultations` que bloquea `pnpm build` del monorepo.

## Contexto
- `consultations → appointments` ya estaba desacoplado en runtime vía `actions.execute('appointments.create', ...)` con try/catch y fallback silencioso (`src/hooks/useConsultationCalendarSync.ts`). El import estático en `package.json` era espurio.
- `appointments → consultations` (imports estáticos de `ServiceLineForm`, `CreateConsultationButton`, etc.) se mantiene: es la dirección natural del kit veterinary.

## Dirección de dependencia acordada
`appointments → consultations` unidireccional. `consultations` es el primitivo clínico (historia + catálogo de servicios); `appointments` es la capa de scheduling por encima. `consultations` puede instalarse sin `appointments`; al revés no.

## Test plan
- [x] `npm run build` passes
- [x] `npm run quality` passes (0 errors, solo warnings preexistentes)
- [ ] Smoke: guardar seguimiento en consulta → verifica que crea el appointment vía action bus
- [ ] Smoke: botón "Atender" en appointments → abre consulta

🤖 Generated with [Claude Code](https://claude.com/claude-code)