### PR TITLE
chore: promote develop to staging

### DIFF
--- a/.changeset/break-appointments-circular-dep.md
+++ b/.changeset/break-appointments-circular-dep.md
@@ -1,0 +1,5 @@
+---
+'@coongro/consultations': patch
+---
+
+fix: remove `@coongro/appointments` from `dependencies` to break the circular package dependency. The runtime coupling (follow-up creates appointment) already uses the SDK action bus with a silent fallback, so the static dependency was unnecessary.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@coongro/appointments": ">=0.1.0",
     "@coongro/calendar": ">=0.1.0",
     "@coongro/patients": ">=0.1.0",
     "@coongro/products": ">=0.1.0",


### PR DESCRIPTION
Promote `develop` → `staging` to publish to Verdaccio staging.

## Changes
- COONG-95: break circular dependency with @coongro/appointments (#64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)