### PR TITLE
fix: require staff_id on consultation and fix default vet (COONG-113)

### DIFF
--- a/.changeset/require-staff-and-fix-default-vet.md
+++ b/.changeset/require-staff-and-fix-default-vet.md
@@ -1,0 +1,8 @@
+---
+'@coongro/consultations': patch
+---
+
+fix: hacer staff_id obligatorio en consulta y corregir aplicación del veterinario predeterminado (COONG-113)
+
+- La validación del veterinario ahora usa el patrón nativo de HTML5 (`required` via input espejo) en lugar de un toast, consistente con "Motivo de consulta *". El campo `vet_name` por texto libre dejó de ser una fallback válida — el staff debe seleccionarse del personal.
+- Cuando se preselecciona el veterinario predeterminado desde el setting `consultations.defaultStaffId`, el form ahora también fetchea el staff member y popula `vet_name` con el contact_name. Antes solo seteaba `staff_id`, lo que dejaba `vet_name` vacío al guardar.

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -222,11 +222,24 @@ export function ConsultationForm(props: ConsultationFormProps) {
     })();
   }, [selectedPetId, defaults?.pet_id, isEditing]);
 
-  // Preseleccionar el ultimo veterinario usado
+  // Preseleccionar el ultimo veterinario usado: aplica staffId + nombre del staff
   useEffect(() => {
-    if (!isEditing && !staffId && consultSettings.defaultStaffId) {
-      setStaffId(consultSettings.defaultStaffId);
-    }
+    if (isEditing || staffId || !consultSettings.defaultStaffId) return;
+    const id = consultSettings.defaultStaffId;
+    let cancelled = false;
+    setStaffId(id);
+    void actions
+      .execute<StaffMember>('staff.members.getById', { id })
+      .then((member) => {
+        if (cancelled || !member) return;
+        setVetName(member.contact_name);
+      })
+      .catch(() => {
+        // Staff no encontrado: el setting puede haber quedado huérfano
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [consultSettings.defaultStaffId, isEditing, staffId]);
 
   // Cargar datos existentes al editar
@@ -307,10 +320,7 @@ export function ConsultationForm(props: ConsultationFormProps) {
         toast.error('Error', 'El motivo de consulta es obligatorio');
         return;
       }
-      if (!staffId && !vetName.trim()) {
-        toast.error('Error', 'Seleccioná un veterinario');
-        return;
-      }
+      // staff_id es obligatorio: validación nativa del browser via input espejo en el form
 
       const validMeds = medications.filter((m: MedicationInput) => m.name.trim());
       const validServices = serviceLines.filter((s: ServiceLineInput) => s.product_name.trim());
@@ -438,12 +448,30 @@ export function ConsultationForm(props: ConsultationFormProps) {
           { className: GRID_2 },
           React.createElement(
             'div',
-            { className: FIELD_GAP },
+            { className: FIELD_GAP, style: { position: 'relative' } },
             React.createElement(UI.Label, null, 'Veterinario *'),
             React.createElement(StaffPicker, {
               value: staffId,
               onChange: handleStaffSelect,
               placeholder: 'Buscar veterinario...',
+            }),
+            // Input espejo para validación nativa "required" sobre el StaffPicker
+            React.createElement('input', {
+              type: 'text',
+              tabIndex: -1,
+              required: true,
+              'aria-label': 'Veterinario',
+              value: staffId ?? '',
+              onChange: () => {},
+              style: {
+                position: 'absolute',
+                bottom: 0,
+                left: 0,
+                width: '100%',
+                height: '1px',
+                opacity: 0,
+                pointerEvents: 'none',
+              },
             })
           ),
           React.createElement(


### PR DESCRIPTION
Work item: COONG-113

## Resumen

Dos arreglos relacionados al kit veterinario básico:

1. **Veterinario obligatorio**: la validación del campo "Veterinario *" pasa a usar HTML5 native `required` (input espejo invisible), consistente con "Motivo de consulta *". El fallback a texto libre `vet_name` sin staff seleccionado deja de ser válido — el staff debe elegirse del personal.
2. **Default vet aplicaba mal**: el setting `consultations.defaultStaffId` preselecciona el `staff_id` pero antes no fetchea el nombre del staff, dejando `vet_name: ''` al guardar. Ahora se hace `staff.members.getById` y se popula `vetName`. Con guard de cancelación para evitar race con selección manual.

## Cambios

- `src/components/ConsultationForm.tsx`:
  - Validación toast reemplazada por `<input required>` espejo posicionado sobre el StaffPicker (`aria-label`, sin `aria-hidden`)
  - useEffect del default vet: fetch del staff member + cancellation flag

## Test plan

- [x] `npm run build`
- [x] `npm run quality`
- [ ] Crear consulta sin elegir vet → tooltip nativo "Por favor completá este campo"
- [ ] Setear default vet → abrir nueva consulta → vet preseleccionado, guardar y verificar que `vet_name` aparece en la lista
- [ ] Editar consulta legacy sin staff_id → bloquea hasta seleccionar staff (intencional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)