### PR TITLE
refactor(ui): adopt FormSection + FormDialogSubmit

### DIFF
--- a/.changeset/detail-views-and-medication-grid.md
+++ b/.changeset/detail-views-and-medication-grid.md
@@ -1,0 +1,13 @@
+---
+'@coongro/consultations': minor
+---
+
+refactor(detail-views): unify detail patterns and fix UX issues (COONG-112)
+
+- **`ConsultationDetail`**: action buttons (Editar/Eliminar/extra) ahora honran `action.variant` y `action.icon` con default `default` (brand) y `size: 'sm'`. Botón "Nueva Consulta" desde el detail view de paciente queda amarillo y consistente con el resto.
+- **Detail view container**: layout `lg:flex-row` (1024px) bajado a `md:flex-row` (768px) para evitar que el sidebar+main se apile cuando el contenedor interno es chico.
+- **`ConsultationDetailView`**: migra delete a `UI.ConfirmDialog` (antes usaba `confirm()` nativo del browser). Edit dialog migrado a `UI.FormDialogSubmit`.
+- **`DetailOverrideView`** (override de PetDetail con timeline de consultas): mismo trato — delete con `UI.ConfirmDialog`, edit con `UI.FormDialogSubmit`. Bug fix: el delete antes mostraba un toast sin borrar nada; ahora usa `usePetMutations.softDelete`.
+- **`DefaultVetSetting`**: removido el workaround de `useCompactCombobox` ya que el fix vive en core (`@coongro/ui-components` 0.29.0).
+- **`MedicationFormList`**: grid de "Dosis + Vía + Duración" ahora usa proporción 2:1:2 (`grid-cols-[2fr_1fr_2fr]` en sm+) y agrega `min-w-0` a los compound fields para que los selects no se pisen entre sí.
+- **`consultation` schema**: `updated_at` ahora se actualiza automáticamente en cada update vía `.$onUpdate()` de Drizzle.

--- a/.changeset/form-section-and-sticky-footer.md
+++ b/.changeset/form-section-and-sticky-footer.md
@@ -1,0 +1,9 @@
+---
+'@coongro/consultations': minor
+---
+
+refactor(ui): adopt FormSection + FormDialogSubmit from `@coongro/ui-components` 0.28.0 (COONG-112)
+
+- Cada sección del SOAP en `ConsultationForm` ahora usa `UI.FormSection` (Card + ícono + título) en vez del helper local `SectionHeader` + `UI.Card`.
+- `CreateConsultationButton` ahora usa `UI.FormDialogSubmit`: footer sticky con botones Cancelar/Registrar consulta siempre visibles, sin importar el scroll del form.
+- `ConsultationForm` expone props nuevas para integrarse con submit externos: `formRef`, `hideActions`, `onSavingChange`. Compatible hacia atrás (todas opcionales).

--- a/src/components/ConsultationDetail.tsx
+++ b/src/components/ConsultationDetail.tsx
@@ -121,10 +121,10 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
       React.createElement(UI.Skeleton, { className: 'h-24 rounded-2xl' }),
       React.createElement(
         'div',
-        { className: 'flex flex-col lg:flex-row gap-6' },
+        { className: 'flex flex-col md:flex-row gap-6' },
         React.createElement(
           'div',
-          { className: 'w-full lg:w-80 flex flex-col gap-4' },
+          { className: 'w-full md:w-80 flex flex-col gap-4' },
           React.createElement(UI.Skeleton, { className: 'h-20 rounded-2xl' }),
           React.createElement(UI.Skeleton, { className: 'h-28 rounded-2xl' }),
           React.createElement(UI.Skeleton, { className: 'h-16 rounded-2xl' })
@@ -227,7 +227,13 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
         extraActions.map((action, i) =>
           React.createElement(
             UI.Button,
-            { key: i, variant: 'outline', size: 'sm', onClick: () => action.onClick(c) },
+            {
+              key: i,
+              variant: action.variant ?? 'default',
+              size: 'sm',
+              onClick: () => action.onClick(c),
+            },
+            action.icon && React.createElement(UI.DynamicIcon, { icon: action.icon, size: 14 }),
             action.label
           )
         )
@@ -299,14 +305,14 @@ export function ConsultationDetail(props: ConsultationDetailProps) {
     // ── Cuerpo en dos columnas ──
     React.createElement(
       'div',
-      { className: 'flex flex-col lg:flex-row gap-6' },
+      { className: 'flex flex-col md:flex-row gap-6' },
 
       // ── PANEL LATERAL ──
       React.createElement(
         'div',
         {
           className:
-            'w-full lg:w-80 lg:shrink-0 flex flex-col gap-4 lg:sticky lg:top-6 lg:self-start',
+            'w-full md:w-80 md:shrink-0 flex flex-col gap-4 md:sticky md:top-6 md:self-start',
         },
 
         // Veterinario

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -49,6 +49,7 @@ const { useState, useCallback, useEffect, useRef, useMemo } = React;
 const FIELD_GAP = 'flex flex-col gap-1';
 const GRID_2 = 'grid grid-cols-2 gap-3';
 
+// Header inline para subsecciones (dentro de un FormSection)
 function SectionHeader({ icon, title }: { icon: string; title: string }) {
   return React.createElement(
     'h3',
@@ -63,7 +64,17 @@ function buildDefaultExamSystems(): PhysicalExamSystem[] {
 }
 
 export function ConsultationForm(props: ConsultationFormProps) {
-  const { consultationId, petId, defaults, onSuccess, onCancel, className = '' } = props;
+  const {
+    consultationId,
+    petId,
+    defaults,
+    onSuccess,
+    onCancel,
+    className = '',
+    formRef,
+    hideActions,
+    onSavingChange,
+  } = props;
 
   const { toast } = usePlugin();
   const tz = useTenantTimezone();
@@ -77,6 +88,11 @@ export function ConsultationForm(props: ConsultationFormProps) {
 
   const isEditing = !!consultationId;
   const saving = creating || updating;
+
+  // Notificar al caller cuando cambia el estado de guardado (para footer externo)
+  useEffect(() => {
+    onSavingChange?.(saving);
+  }, [saving, onSavingChange]);
 
   // --- Estado del formulario ---
   const [selectedPetId, setSelectedPetId] = useState(petId ?? defaults?.pet_id ?? '');
@@ -419,383 +435,343 @@ export function ConsultationForm(props: ConsultationFormProps) {
 
   return React.createElement(
     'form',
-    { onSubmit: handleSubmit, className: `flex flex-col gap-4 ${className}` },
+    { ref: formRef, onSubmit: handleSubmit, className: `flex flex-col gap-4 ${className}` },
 
     // ── Sección 1: Datos básicos + Paciente ──
     React.createElement(
-      UI.Card,
-      { className: 'p-4' },
-      React.createElement(
-        'div',
-        { className: 'flex flex-col gap-3' },
-        React.createElement(SectionHeader, { icon: 'ClipboardList', title: 'Datos básicos' }),
+      UI.FormSection,
+      { icon: 'ClipboardList', title: 'Datos básicos' },
 
-        // PetPicker (solo cuando no viene petId por parámetro)
-        needsPetPicker &&
-          React.createElement(
-            'div',
-            { className: FIELD_GAP },
-            React.createElement(UI.Label, null, 'Paciente *'),
-            React.createElement(PetPicker, {
-              value: selectedPetId || undefined,
-              onChange: handlePetSelect,
-              placeholder: 'Buscar paciente por nombre, raza o microchip...',
-            })
-          ),
-
+      // PetPicker (solo cuando no viene petId por parámetro)
+      needsPetPicker &&
         React.createElement(
           'div',
-          { className: GRID_2 },
-          React.createElement(
-            'div',
-            { className: FIELD_GAP, style: { position: 'relative' } },
-            React.createElement(UI.Label, null, 'Veterinario *'),
-            React.createElement(StaffPicker, {
-              value: staffId,
-              onChange: handleStaffSelect,
-              placeholder: 'Buscar veterinario...',
-            }),
-            // Input espejo para validación nativa "required" sobre el StaffPicker
-            React.createElement('input', {
-              type: 'text',
-              tabIndex: -1,
-              required: true,
-              'aria-label': 'Veterinario',
-              value: staffId ?? '',
-              onChange: () => {},
-              style: {
-                position: 'absolute',
-                bottom: 0,
-                left: 0,
-                width: '100%',
-                height: '1px',
-                opacity: 0,
-                pointerEvents: 'none',
-              },
-            })
-          ),
-          React.createElement(
-            'div',
-            { className: FIELD_GAP },
-            React.createElement(UI.Label, null, 'Fecha y hora'),
-            React.createElement(DateTimePicker, {
-              value: date,
-              onChange: setDate,
-              step: 30,
-            })
-          )
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'Paciente *'),
+          React.createElement(PetPicker, {
+            value: selectedPetId || undefined,
+            onChange: handlePetSelect,
+            placeholder: 'Buscar paciente por nombre, raza o microchip...',
+          })
+        ),
+
+      React.createElement(
+        'div',
+        { className: GRID_2 },
+        React.createElement(
+          'div',
+          { className: FIELD_GAP, style: { position: 'relative' } },
+          React.createElement(UI.Label, null, 'Veterinario *'),
+          React.createElement(StaffPicker, {
+            value: staffId,
+            onChange: handleStaffSelect,
+            placeholder: 'Buscar veterinario...',
+          }),
+          // Input espejo para validación nativa "required" sobre el StaffPicker
+          React.createElement('input', {
+            type: 'text',
+            tabIndex: -1,
+            required: true,
+            'aria-label': 'Veterinario',
+            value: staffId ?? '',
+            onChange: () => {},
+            style: {
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              width: '100%',
+              height: '1px',
+              opacity: 0,
+              pointerEvents: 'none',
+            },
+          })
+        ),
+        React.createElement(
+          'div',
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'Fecha y hora'),
+          React.createElement(DateTimePicker, {
+            value: date,
+            onChange: setDate,
+            step: 30,
+          })
         )
       )
     ),
 
     // ── Sección 2: Signos vitales ──
     React.createElement(
-      UI.Card,
-      { className: 'p-4' },
+      UI.FormSection,
+      { icon: 'HeartPulse', title: 'Signos vitales' },
       React.createElement(
         'div',
-        { className: 'flex flex-col gap-3' },
-        React.createElement(SectionHeader, { icon: 'HeartPulse', title: 'Signos vitales' }),
+        { className: 'grid grid-cols-3 sm:grid-cols-5 gap-3' },
         React.createElement(
           'div',
-          { className: 'grid grid-cols-3 sm:grid-cols-5 gap-3' },
-          React.createElement(
-            'div',
-            { className: FIELD_GAP },
-            React.createElement(UI.Label, null, 'Peso (kg)'),
-            React.createElement(UI.Input, {
-              type: 'number',
-              step: '0.1',
-              min: '0',
-              max: '200',
-              value: weightKg,
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) => setWeightKg(e.target.value),
-              placeholder: '28.5',
-            })
-          ),
-          React.createElement(
-            'div',
-            { className: FIELD_GAP },
-            React.createElement(UI.Label, null, 'Temp. (°C)'),
-            React.createElement(UI.Input, {
-              type: 'number',
-              step: '0.1',
-              min: '35',
-              max: '42',
-              value: temperature,
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) => setTemperature(e.target.value),
-              placeholder: '38.5',
-            })
-          ),
-          React.createElement(
-            'div',
-            { className: FIELD_GAP },
-            React.createElement(UI.Label, null, 'FC (lpm)'),
-            React.createElement(UI.Input, {
-              type: 'number',
-              min: '0',
-              max: '300',
-              value: heartRate,
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) => setHeartRate(e.target.value),
-              placeholder: '120',
-            })
-          ),
-          React.createElement(
-            'div',
-            { className: FIELD_GAP },
-            React.createElement(UI.Label, null, 'FR (rpm)'),
-            React.createElement(UI.Input, {
-              type: 'number',
-              min: '0',
-              max: '100',
-              value: respiratoryRate,
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                setRespiratoryRate(e.target.value),
-              placeholder: '20',
-            })
-          ),
-          React.createElement(
-            'div',
-            { className: FIELD_GAP },
-            React.createElement(UI.Label, null, 'BCS (1-9)'),
-            React.createElement(UI.Input, {
-              type: 'number',
-              min: '1',
-              max: '9',
-              step: '0.5',
-              value: bcs,
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) => setBcs(e.target.value),
-              placeholder: '5',
-            })
-          )
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'Peso (kg)'),
+          React.createElement(UI.Input, {
+            type: 'number',
+            step: '0.1',
+            min: '0',
+            max: '200',
+            value: weightKg,
+            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setWeightKg(e.target.value),
+            placeholder: '28.5',
+          })
+        ),
+        React.createElement(
+          'div',
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'Temp. (°C)'),
+          React.createElement(UI.Input, {
+            type: 'number',
+            step: '0.1',
+            min: '35',
+            max: '42',
+            value: temperature,
+            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setTemperature(e.target.value),
+            placeholder: '38.5',
+          })
+        ),
+        React.createElement(
+          'div',
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'FC (lpm)'),
+          React.createElement(UI.Input, {
+            type: 'number',
+            min: '0',
+            max: '300',
+            value: heartRate,
+            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setHeartRate(e.target.value),
+            placeholder: '120',
+          })
+        ),
+        React.createElement(
+          'div',
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'FR (rpm)'),
+          React.createElement(UI.Input, {
+            type: 'number',
+            min: '0',
+            max: '100',
+            value: respiratoryRate,
+            onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+              setRespiratoryRate(e.target.value),
+            placeholder: '20',
+          })
+        ),
+        React.createElement(
+          'div',
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'BCS (1-9)'),
+          React.createElement(UI.Input, {
+            type: 'number',
+            min: '1',
+            max: '9',
+            step: '0.5',
+            value: bcs,
+            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setBcs(e.target.value),
+            placeholder: '5',
+          })
         )
       )
     ),
 
     // ── Sección 3 (S): Motivo + Anamnesis ──
     React.createElement(
-      UI.Card,
-      { className: 'p-4' },
+      UI.FormSection,
+      { icon: 'MessageSquare', title: 'S — Motivo y anamnesis' },
       React.createElement(
         'div',
-        { className: 'flex flex-col gap-3' },
-        React.createElement(SectionHeader, {
-          icon: 'MessageSquare',
-          title: 'S — Motivo y anamnesis',
-        }),
-        React.createElement(
-          'div',
-          { className: FIELD_GAP },
-          React.createElement(UI.Label, null, 'Motivo de consulta *'),
-          React.createElement(UI.Input, {
-            type: 'text',
-            value: reason,
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setReason(e.target.value),
-            placeholder: 'Ej: Control anual, vacunación, vómitos...',
-            required: true,
-          })
-        ),
-        React.createElement(
-          'div',
-          { className: FIELD_GAP },
-          React.createElement(UI.Label, null, 'Anamnesis'),
-          React.createElement(UI.Textarea, {
-            value: anamnesis,
-            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setAnamnesis(e.target.value),
-            placeholder: 'Lo que reporta el dueño: síntomas, duración, cambios de hábitos...',
-            rows: 3,
-          })
-        )
+        { className: FIELD_GAP },
+        React.createElement(UI.Label, null, 'Motivo de consulta *'),
+        React.createElement(UI.Input, {
+          type: 'text',
+          value: reason,
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) => setReason(e.target.value),
+          placeholder: 'Ej: Control anual, vacunación, vómitos...',
+          required: true,
+        })
+      ),
+      React.createElement(
+        'div',
+        { className: FIELD_GAP },
+        React.createElement(UI.Label, null, 'Anamnesis'),
+        React.createElement(UI.Textarea, {
+          value: anamnesis,
+          onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setAnamnesis(e.target.value),
+          placeholder: 'Lo que reporta el dueño: síntomas, duración, cambios de hábitos...',
+          rows: 3,
+        })
       )
     ),
 
     // ── Sección 4 (O): Examen físico ──
     React.createElement(
-      UI.Card,
-      { className: 'p-4' },
-      React.createElement(
-        'div',
-        { className: 'flex flex-col gap-3' },
-        React.createElement(SectionHeader, {
-          icon: 'Stethoscope',
-          title: 'O — Examen físico',
+      UI.FormSection,
+      { icon: 'Stethoscope', title: 'O — Examen físico' },
+
+      // Checklist por sistemas (si structuredExam habilitado)
+      consultSettings.structuredExam &&
+        React.createElement(ExamSystemList, {
+          systems: examSystems,
+          onStatusToggle: handleExamStatusToggle,
+          onNotesChange: handleExamNotesChange,
         }),
 
-        // Checklist por sistemas (si structuredExam habilitado)
-        consultSettings.structuredExam &&
-          React.createElement(ExamSystemList, {
-            systems: examSystems,
-            onStatusToggle: handleExamStatusToggle,
-            onNotesChange: handleExamNotesChange,
-          }),
-
-        // Textarea libre (siempre visible como notas adicionales si structured, o como único campo si no)
+      // Textarea libre (siempre visible como notas adicionales si structured, o como único campo si no)
+      React.createElement(
+        'div',
+        { className: FIELD_GAP },
         React.createElement(
-          'div',
-          { className: FIELD_GAP },
-          React.createElement(
-            UI.Label,
-            null,
-            consultSettings.structuredExam ? 'Notas generales del examen' : 'Examen físico'
-          ),
-          React.createElement(UI.Textarea, {
-            value: physicalExamNotes,
-            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-              setPhysicalExamNotes(e.target.value),
-            placeholder: consultSettings.structuredExam
-              ? 'Observaciones adicionales del examen físico...'
-              : 'Hallazgos del examen físico...',
-            rows: consultSettings.structuredExam ? 2 : 4,
-          })
-        )
+          UI.Label,
+          null,
+          consultSettings.structuredExam ? 'Notas generales del examen' : 'Examen físico'
+        ),
+        React.createElement(UI.Textarea, {
+          value: physicalExamNotes,
+          onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
+            setPhysicalExamNotes(e.target.value),
+          placeholder: consultSettings.structuredExam
+            ? 'Observaciones adicionales del examen físico...'
+            : 'Hallazgos del examen físico...',
+          rows: consultSettings.structuredExam ? 2 : 4,
+        })
       )
     ),
 
     // ── Sección 5 (A): Diagnóstico ──
     React.createElement(
-      UI.Card,
-      { className: 'p-4' },
-      React.createElement(
-        'div',
-        { className: 'flex flex-col gap-3' },
-        React.createElement(SectionHeader, { icon: 'SearchCheck', title: 'A — Diagnóstico' }),
-        React.createElement(UI.Textarea, {
-          value: diagnosis,
-          onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setDiagnosis(e.target.value),
-          placeholder: 'Diagnóstico presuntivo o definitivo...',
-          rows: 2,
-        })
-      )
+      UI.FormSection,
+      { icon: 'SearchCheck', title: 'A — Diagnóstico' },
+      React.createElement(UI.Textarea, {
+        value: diagnosis,
+        onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => setDiagnosis(e.target.value),
+        placeholder: 'Diagnóstico presuntivo o definitivo...',
+        rows: 2,
+      })
     ),
 
     // ── Sección 6 (P): Tratamiento + Medicamentos + Seguimiento ──
     React.createElement(
-      UI.Card,
-      { className: 'p-4' },
+      UI.FormSection,
+      { icon: 'Pill', title: 'P — Plan de tratamiento' },
       React.createElement(
         'div',
-        { className: 'flex flex-col gap-3' },
-        React.createElement(SectionHeader, { icon: 'Pill', title: 'P — Plan de tratamiento' }),
+        { className: FIELD_GAP },
+        React.createElement(UI.Label, null, 'Indicaciones generales'),
+        React.createElement(UI.Input, {
+          type: 'text',
+          value: treatment,
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) => setTreatment(e.target.value),
+          placeholder: 'Ej: Dieta blanda, reposo, collar isabelino...',
+        })
+      ),
+      React.createElement(UI.Label, null, 'Medicación'),
+      ...(contributedSections.length > 0
+        ? contributedSections.map((s, i) =>
+            React.createElement(
+              React.Fragment,
+              { key: `contrib-${String(i)}` },
+              s.render() as React.ReactNode
+            )
+          )
+        : [
+            React.createElement(MedicationFormList, {
+              key: 'native-meds',
+              medications,
+              onChange: setMedications,
+            }),
+          ]),
+      React.createElement(UI.Separator, { className: 'my-1' }),
+      React.createElement(SectionHeader, { icon: 'CalendarCheck', title: 'Seguimiento' }),
+      React.createElement(
+        'div',
+        { className: 'grid grid-cols-4 gap-3' },
         React.createElement(
           'div',
           { className: FIELD_GAP },
-          React.createElement(UI.Label, null, 'Indicaciones generales'),
-          React.createElement(UI.Input, {
-            type: 'text',
-            value: treatment,
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setTreatment(e.target.value),
-            placeholder: 'Ej: Dieta blanda, reposo, collar isabelino...',
+          React.createElement(UI.Label, null, 'Próximo control'),
+          React.createElement(DatePicker, {
+            value: followUpDate,
+            onChange: setFollowUpDate,
+            placeholder: 'Seleccionar fecha',
+            minDate: toDateKey(new Date(), tz),
           })
         ),
-        React.createElement(UI.Label, null, 'Medicación'),
-        ...(contributedSections.length > 0
-          ? contributedSections.map((s, i) =>
-              React.createElement(
-                React.Fragment,
-                { key: `contrib-${String(i)}` },
-                s.render() as React.ReactNode
-              )
-            )
-          : [
-              React.createElement(MedicationFormList, {
-                key: 'native-meds',
-                medications,
-                onChange: setMedications,
-              }),
-            ]),
-        React.createElement(UI.Separator, { className: 'my-1' }),
-        React.createElement(SectionHeader, { icon: 'CalendarCheck', title: 'Seguimiento' }),
         React.createElement(
           'div',
-          { className: 'grid grid-cols-4 gap-3' },
-          React.createElement(
-            'div',
-            { className: FIELD_GAP },
-            React.createElement(UI.Label, null, 'Próximo control'),
-            React.createElement(DatePicker, {
-              value: followUpDate,
-              onChange: setFollowUpDate,
-              placeholder: 'Seleccionar fecha',
-              minDate: toDateKey(new Date(), tz),
-            })
-          ),
-          React.createElement(
-            'div',
-            { className: FIELD_GAP },
-            React.createElement(UI.Label, null, 'Inicio'),
-            React.createElement(TimePicker, {
-              value: followUpStartTime,
-              onChange: (t: string) => {
-                setFollowUpStartTime(t);
-                const [h, m] = t.split(':').map(Number);
-                const endMin = h * 60 + m + 30;
-                setFollowUpEndTime(
-                  `${String(Math.floor(endMin / 60) % 24).padStart(2, '0')}:${String(endMin % 60).padStart(2, '0')}`
-                );
-              },
-              step: 30,
-            })
-          ),
-          React.createElement(
-            'div',
-            { className: FIELD_GAP },
-            React.createElement(UI.Label, null, 'Fin'),
-            React.createElement(TimePicker, {
-              value: followUpEndTime,
-              onChange: setFollowUpEndTime,
-              step: 30,
-            })
-          ),
-          React.createElement(
-            'div',
-            { className: FIELD_GAP },
-            React.createElement(UI.Label, null, 'Notas'),
-            React.createElement(UI.Input, {
-              type: 'text',
-              value: notes,
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) => setNotes(e.target.value),
-              placeholder: 'Observaciones, indicaciones para el próximo control...',
-            })
-          )
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'Inicio'),
+          React.createElement(TimePicker, {
+            value: followUpStartTime,
+            onChange: (t: string) => {
+              setFollowUpStartTime(t);
+              const [h, m] = t.split(':').map(Number);
+              const endMin = h * 60 + m + 30;
+              setFollowUpEndTime(
+                `${String(Math.floor(endMin / 60) % 24).padStart(2, '0')}:${String(endMin % 60).padStart(2, '0')}`
+              );
+            },
+            step: 30,
+          })
+        ),
+        React.createElement(
+          'div',
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'Fin'),
+          React.createElement(TimePicker, {
+            value: followUpEndTime,
+            onChange: setFollowUpEndTime,
+            step: 30,
+          })
+        ),
+        React.createElement(
+          'div',
+          { className: FIELD_GAP },
+          React.createElement(UI.Label, null, 'Notas'),
+          React.createElement(UI.Input, {
+            type: 'text',
+            value: notes,
+            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setNotes(e.target.value),
+            placeholder: 'Observaciones, indicaciones para el próximo control...',
+          })
         )
       )
     ),
 
     // ── Sección 7: Servicios prestados ──
     React.createElement(
-      UI.Card,
-      { className: 'p-4' },
-      React.createElement(
-        'div',
-        { className: 'flex flex-col gap-3' },
-        React.createElement(SectionHeader, { icon: 'Receipt', title: 'Servicios prestados' }),
-        React.createElement(ServiceLineForm, {
-          services: serviceLines,
-          onChange: setServiceLines,
-          catalog: serviceCatalog,
-          categories: serviceSubcategories,
-          catalogLoading,
-          onProductCreated: handleProductCreated,
-          showPrices: consultSettings.showPrices,
-        })
-      )
+      UI.FormSection,
+      { icon: 'Receipt', title: 'Servicios prestados' },
+      React.createElement(ServiceLineForm, {
+        services: serviceLines,
+        onChange: setServiceLines,
+        catalog: serviceCatalog,
+        categories: serviceSubcategories,
+        catalogLoading,
+        onProductCreated: handleProductCreated,
+        showPrices: consultSettings.showPrices,
+      })
     ),
 
-    // ── Botones ──
-    React.createElement(
-      'div',
-      { className: 'flex justify-end gap-3' },
-      onCancel &&
+    // ── Botones (solo si el caller no los pone en el footer del dialog) ──
+    !hideActions &&
+      React.createElement(
+        'div',
+        { className: 'flex justify-end gap-3' },
+        onCancel &&
+          React.createElement(
+            UI.Button,
+            { type: 'button', variant: 'outline', onClick: onCancel },
+            'Cancelar'
+          ),
         React.createElement(
           UI.Button,
-          { type: 'button', variant: 'outline', onClick: onCancel },
-          'Cancelar'
-        ),
-      React.createElement(
-        UI.Button,
-        { type: 'submit', disabled: saving },
-        saving ? 'Guardando...' : isEditing ? 'Guardar cambios' : 'Registrar consulta'
+          { type: 'submit', disabled: saving },
+          saving ? 'Guardando...' : isEditing ? 'Guardar cambios' : 'Registrar consulta'
+        )
       )
-    )
   );
 }

--- a/src/components/CreateConsultationButton.tsx
+++ b/src/components/CreateConsultationButton.tsx
@@ -1,5 +1,5 @@
 /**
- * Botón para crear consulta. Abre un FormDialog con PetPicker + ConsultationForm.
+ * Botón para crear consulta. Abre un FormDialogSubmit con PetPicker + ConsultationForm.
  *
  * Modos de uso:
  *   - Sin petId: muestra PetPicker para seleccionar mascota, luego ConsultationForm
@@ -36,6 +36,7 @@ export function CreateConsultationButton(props: CreateConsultationButtonProps) {
   const open = isControlled ? openProp : openState;
 
   const [selectedPetId, setSelectedPetId] = useState<string | undefined>(petIdProp);
+  const targetPetId = petIdProp ?? selectedPetId;
 
   const setOpen = useCallback(
     (val: boolean) => {
@@ -83,47 +84,55 @@ export function CreateConsultationButton(props: CreateConsultationButtonProps) {
         label
       ),
 
-    // Modal
-    React.createElement(UI.FormDialog, {
+    // Modal con footer sticky vía FormDialogSubmit
+    React.createElement(UI.FormDialogSubmit, {
       open,
       onOpenChange: (val: boolean) => {
         if (!val) handleClose();
       },
       title: label,
       size: 'lg',
-      children: petIdProp
-        ? // Con petId: formulario directo
-          React.createElement(ConsultationForm, {
-            petId: petIdProp,
-            defaults,
-            onSuccess: handleSuccess,
-            onCancel: handleClose,
-          })
-        : // Sin petId: PetPicker primero, luego formulario
-          React.createElement(
-            'div',
-            { className: 'flex flex-col gap-4' },
+      submitLabel: 'Registrar consulta',
+      onCancel: handleClose,
+      disabled: !targetPetId,
+      children: ({ formRef, onSavingChange }) =>
+        petIdProp
+          ? // Con petId: formulario directo
+            React.createElement(ConsultationForm, {
+              petId: petIdProp,
+              defaults,
+              onSuccess: handleSuccess,
+              formRef,
+              hideActions: true,
+              onSavingChange,
+            })
+          : // Sin petId: PetPicker primero, luego formulario
             React.createElement(
               'div',
-              { className: 'flex flex-col gap-1' },
-              React.createElement(UI.Label, null, 'Paciente *'),
-              React.createElement(PetPicker, {
-                value: selectedPetId,
-                onChange: (pet: Pet | null) => setSelectedPetId(pet?.id),
-                placeholder: 'Seleccionar mascota...',
-              })
+              { className: 'flex flex-col gap-4' },
+              React.createElement(
+                'div',
+                { className: 'flex flex-col gap-1' },
+                React.createElement(UI.Label, null, 'Paciente *'),
+                React.createElement(PetPicker, {
+                  value: selectedPetId,
+                  onChange: (pet: Pet | null) => setSelectedPetId(pet?.id),
+                  placeholder: 'Seleccionar mascota...',
+                })
+              ),
+              selectedPetId
+                ? React.createElement(ConsultationForm, {
+                    petId: selectedPetId,
+                    defaults,
+                    onSuccess: handleSuccess,
+                    formRef,
+                    hideActions: true,
+                    onSavingChange,
+                  })
+                : React.createElement(UI.EmptyState, {
+                    title: 'Seleccioná un paciente para continuar',
+                  })
             ),
-            selectedPetId
-              ? React.createElement(ConsultationForm, {
-                  petId: selectedPetId,
-                  defaults,
-                  onSuccess: handleSuccess,
-                  onCancel: handleClose,
-                })
-              : React.createElement(UI.EmptyState, {
-                  title: 'Seleccioná un paciente para continuar',
-                })
-          ),
     })
   );
 }

--- a/src/components/DefaultVetSetting.tsx
+++ b/src/components/DefaultVetSetting.tsx
@@ -8,48 +8,13 @@ import type { StaffMember } from '@coongro/staff';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useState, useEffect, useCallback, useRef } = React;
+const { useState, useEffect, useCallback } = React;
 
 const SETTING_KEY = 'consultations.defaultStaffId';
-
-/**
- * Fuerza el ComboboxChipTrigger a una sola linea.
- * El trigger usa flex-wrap que causa dos lineas cuando hay chip + input.
- */
-function useCompactCombobox(containerRef: React.RefObject<HTMLDivElement>, hasValue: boolean) {
-  useEffect(() => {
-    if (!containerRef.current) return;
-    const trigger = containerRef.current.querySelector<HTMLElement>('[role="combobox"]');
-    if (!trigger) return;
-
-    trigger.style.flexWrap = 'nowrap';
-    trigger.style.overflow = 'hidden';
-
-    const input = trigger.querySelector<HTMLInputElement>('input');
-    if (input) {
-      if (hasValue) {
-        input.style.width = '0';
-        input.style.minWidth = '0';
-        input.style.padding = '0';
-        input.style.opacity = '0';
-        input.style.position = 'absolute';
-      } else {
-        input.style.width = '';
-        input.style.minWidth = '';
-        input.style.padding = '';
-        input.style.opacity = '';
-        input.style.position = '';
-      }
-    }
-  }, [hasValue]);
-}
 
 export function DefaultVetSetting() {
   const [staffId, setStaffId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const pickerRef = useRef<HTMLDivElement>(null);
-
-  useCompactCombobox(pickerRef, !!staffId);
 
   useEffect(() => {
     void (async () => {
@@ -104,7 +69,7 @@ export function DefaultVetSetting() {
     ),
     React.createElement(
       'div',
-      { ref: pickerRef, style: { width: '220px', flexShrink: 0 } },
+      { style: { width: '220px', flexShrink: 0 } },
       React.createElement(StaffPicker, {
         value: staffId,
         onChange: handleChange,

--- a/src/components/MedicationFormList.tsx
+++ b/src/components/MedicationFormList.tsx
@@ -220,19 +220,21 @@ export function MedicationFormList({
             })
           ),
 
-          // Fila 1: Dosis + Via + Duracion
+          // Fila 1: Dosis + Via + Duracion (compound fields get más ancho que Vía)
           React.createElement(
             'div',
-            { className: 'grid grid-cols-2 sm:grid-cols-3 gap-2' },
+            {
+              className: 'grid grid-cols-2 sm:grid-cols-[2fr_1fr_2fr] gap-2',
+            },
 
             // Dosis (compound: numero + select)
             React.createElement(
               'div',
-              { className: 'flex flex-col gap-1' },
+              { className: 'flex flex-col gap-1 min-w-0' },
               React.createElement(UI.Label, null, 'Dosis *'),
               React.createElement(
                 'div',
-                { className: 'flex gap-1' },
+                { className: 'flex gap-1 min-w-0' },
                 React.createElement(UI.Input, {
                   type: 'number',
                   step: '0.01',
@@ -245,13 +247,17 @@ export function MedicationFormList({
                   className: 'w-20',
                 }),
                 React.createElement(
-                  UI.Select,
-                  {
-                    value: med.dosage_unit ?? 'mg/kg',
-                    onValueChange: (v: string) => updateField(index, 'dosage_unit', v),
-                  },
-                  DOSAGE_UNITS.map((unit) =>
-                    React.createElement(UI.SelectItem, { key: unit, value: unit }, unit)
+                  'div',
+                  { className: 'flex-1 min-w-0' },
+                  React.createElement(
+                    UI.Select,
+                    {
+                      value: med.dosage_unit ?? 'mg/kg',
+                      onValueChange: (v: string) => updateField(index, 'dosage_unit', v),
+                    },
+                    DOSAGE_UNITS.map((unit) =>
+                      React.createElement(UI.SelectItem, { key: unit, value: unit }, unit)
+                    )
                   )
                 )
               )
@@ -260,7 +266,7 @@ export function MedicationFormList({
             // Via
             React.createElement(
               'div',
-              { className: 'flex flex-col gap-1' },
+              { className: 'flex flex-col gap-1 min-w-0' },
               React.createElement(UI.Label, null, 'Vía'),
               React.createElement(
                 UI.Select,
@@ -277,11 +283,11 @@ export function MedicationFormList({
             // Duracion (compound: numero + select)
             React.createElement(
               'div',
-              { className: 'flex flex-col gap-1' },
+              { className: 'flex flex-col gap-1 min-w-0' },
               React.createElement(UI.Label, null, 'Duración *'),
               React.createElement(
                 'div',
-                { className: 'flex gap-1' },
+                { className: 'flex gap-1 min-w-0' },
                 React.createElement(UI.Input, {
                   type: 'number',
                   step: '1',
@@ -298,13 +304,17 @@ export function MedicationFormList({
                   className: 'w-16',
                 }),
                 React.createElement(
-                  UI.Select,
-                  {
-                    value: med.duration_unit ?? 'días',
-                    onValueChange: (v: string) => updateField(index, 'duration_unit', v),
-                  },
-                  DURATION_UNITS.map((unit) =>
-                    React.createElement(UI.SelectItem, { key: unit, value: unit }, unit)
+                  'div',
+                  { className: 'flex-1 min-w-0' },
+                  React.createElement(
+                    UI.Select,
+                    {
+                      value: med.duration_unit ?? 'días',
+                      onValueChange: (v: string) => updateField(index, 'duration_unit', v),
+                    },
+                    DURATION_UNITS.map((unit) =>
+                      React.createElement(UI.SelectItem, { key: unit, value: unit }, unit)
+                    )
                   )
                 )
               )

--- a/src/components/ServiceFormDialog.tsx
+++ b/src/components/ServiceFormDialog.tsx
@@ -104,127 +104,116 @@ export function ServiceFormDialog({
     if (ok) onClose();
   }, [form, onSave, onClose]);
 
-  const submitLabel = saving ? 'Guardando...' : isEditing ? 'Guardar cambios' : 'Crear servicio';
-
-  return React.createElement(UI.FormDialog, {
+  return React.createElement(UI.FormDialogSubmit, {
     open,
     onOpenChange: (o: boolean) => {
       if (!o) onClose();
     },
     title: isEditing ? 'Editar servicio' : 'Nuevo servicio',
     size: 'sm',
-    footer: React.createElement(
-      React.Fragment,
-      null,
+    submitLabel: isEditing ? 'Guardar cambios' : 'Crear servicio',
+    onCancel: onClose,
+    disabled: !form.name.trim() || saving,
+    children: ({ formRef }: { formRef: React.RefObject<HTMLFormElement> }) =>
       React.createElement(
-        UI.Button,
-        { type: 'button', variant: 'outline', onClick: onClose },
-        'Cancelar'
-      ),
-      React.createElement(
-        UI.Button,
+        'form',
         {
-          type: 'button',
-          onClick: () => {
+          ref: formRef,
+          onSubmit: (e: React.FormEvent) => {
+            e.preventDefault();
             void handleSubmit();
           },
-          disabled: saving || !form.name.trim(),
+          className: 'flex flex-col gap-4',
         },
-        submitLabel
-      )
-    ),
-    children: React.createElement(
-      'div',
-      { className: 'flex flex-col gap-4' },
 
-      // Nombre
-      React.createElement(
-        'div',
-        { className: 'flex flex-col gap-1.5' },
-        React.createElement(UI.Label, { htmlFor: 'svc-name' }, 'Nombre *'),
-        React.createElement(UI.Input, {
-          id: 'svc-name',
-          type: 'text',
-          value: form.name,
-          onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-            setForm((prev: ServiceFormValues) => ({ ...prev, name: e.target.value })),
-          onBlur: () => handleBlur('name'),
-          placeholder: 'Ej: Consulta general',
-          maxLength: 200,
-          autoFocus: !isEditing,
-          'aria-invalid': touched.name && !!errors.name,
-          className: touched.name && errors.name ? 'border-cg-danger' : '',
-        }),
-        touched.name &&
-          errors.name &&
-          React.createElement(
-            'p',
-            { className: 'text-xs text-cg-danger', role: 'alert' },
-            errors.name
-          )
-      ),
-
-      // Descripción (opcional, configurable)
-      showDescription &&
+        // Nombre
         React.createElement(
           'div',
           { className: 'flex flex-col gap-1.5' },
-          React.createElement(UI.Label, { htmlFor: 'svc-desc' }, 'Descripción (opcional)'),
-          React.createElement(UI.Textarea, {
-            id: 'svc-desc',
-            value: form.description,
-            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-              setForm((prev: ServiceFormValues) => ({
-                ...prev,
-                description: e.target.value,
-              })),
-            rows: 2,
-            placeholder: 'Ej: Incluye análisis de sangre completo',
-            maxLength: 500,
-          })
+          React.createElement(UI.Label, { htmlFor: 'svc-name' }, 'Nombre *'),
+          React.createElement(UI.Input, {
+            id: 'svc-name',
+            type: 'text',
+            value: form.name,
+            onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+              setForm((prev: ServiceFormValues) => ({ ...prev, name: e.target.value })),
+            onBlur: () => handleBlur('name'),
+            placeholder: 'Ej: Consulta general',
+            maxLength: 200,
+            autoFocus: !isEditing,
+            'aria-invalid': touched.name && !!errors.name,
+            className: touched.name && errors.name ? 'border-cg-danger' : '',
+          }),
+          touched.name &&
+            errors.name &&
+            React.createElement(
+              'p',
+              { className: 'text-xs text-cg-danger', role: 'alert' },
+              errors.name
+            )
         ),
 
-      // Categoría + Precio
-      React.createElement(
-        'div',
-        { className: 'grid grid-cols-1 sm:grid-cols-2 gap-4' },
-
-        categories.length > 0 &&
+        // Descripción (opcional, configurable)
+        showDescription &&
           React.createElement(
             'div',
             { className: 'flex flex-col gap-1.5' },
-            React.createElement(UI.Label, null, 'Categoría'),
-            React.createElement(
-              UI.Select,
-              {
-                value: form.categoryId,
-                onValueChange: (v: string) =>
-                  setForm((prev: ServiceFormValues) => ({
-                    ...prev,
-                    categoryId: v,
-                  })),
-              },
-              categories.map((cat: Category) =>
-                React.createElement(UI.SelectItem, { key: cat.id, value: cat.id }, cat.name)
-              )
-            )
+            React.createElement(UI.Label, { htmlFor: 'svc-desc' }, 'Descripción (opcional)'),
+            React.createElement(UI.Textarea, {
+              id: 'svc-desc',
+              value: form.description,
+              onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                setForm((prev: ServiceFormValues) => ({
+                  ...prev,
+                  description: e.target.value,
+                })),
+              rows: 2,
+              placeholder: 'Ej: Incluye análisis de sangre completo',
+              maxLength: 500,
+            })
           ),
 
+        // Categoría + Precio
         React.createElement(
           'div',
-          { className: 'flex flex-col gap-1.5' },
-          React.createElement(UI.Label, { htmlFor: 'svc-price' }, 'Precio'),
-          React.createElement(PriceInput, {
-            id: 'svc-price',
-            value: form.price,
-            onChange: (val: string) =>
-              setForm((prev: ServiceFormValues) => ({ ...prev, price: val })),
-            onBlur: () => handleBlur('price'),
-            hasError: !!touched.price && !!errors.price,
-            errorMessage: errors.price,
-          })
+          { className: 'grid grid-cols-1 sm:grid-cols-2 gap-4' },
+
+          categories.length > 0 &&
+            React.createElement(
+              'div',
+              { className: 'flex flex-col gap-1.5' },
+              React.createElement(UI.Label, null, 'Categoría'),
+              React.createElement(
+                UI.Select,
+                {
+                  value: form.categoryId,
+                  onValueChange: (v: string) =>
+                    setForm((prev: ServiceFormValues) => ({
+                      ...prev,
+                      categoryId: v,
+                    })),
+                },
+                categories.map((cat: Category) =>
+                  React.createElement(UI.SelectItem, { key: cat.id, value: cat.id }, cat.name)
+                )
+              )
+            ),
+
+          React.createElement(
+            'div',
+            { className: 'flex flex-col gap-1.5' },
+            React.createElement(UI.Label, { htmlFor: 'svc-price' }, 'Precio'),
+            React.createElement(PriceInput, {
+              id: 'svc-price',
+              value: form.price,
+              onChange: (val: string) =>
+                setForm((prev: ServiceFormValues) => ({ ...prev, price: val })),
+              onBlur: () => handleBlur('price'),
+              hasError: !!touched.price && !!errors.price,
+              errorMessage: errors.price,
+            })
+          )
         )
-      )
-    ),
+      ),
   });
 }

--- a/src/schema/consultation.ts
+++ b/src/schema/consultation.ts
@@ -45,7 +45,8 @@ export const consultationTable = pgTable('module_consultations_consultations', {
     .default(sql`now()`),
   updated_at: timestamp('updated_at', { mode: 'date', withTimezone: true })
     .notNull()
-    .default(sql`now()`),
+    .default(sql`now()`)
+    .$onUpdate(() => new Date()),
 });
 
 export type ConsultationRow = typeof consultationTable.$inferSelect;

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -1,6 +1,8 @@
 /**
  * Props para todos los componentes reutilizables de consultations.
  */
+import type * as React from 'react';
+
 import type {
   Consultation,
   ConsultationCreateData,
@@ -66,6 +68,12 @@ export interface ConsultationFormProps {
   onSuccess?: (consultation: Consultation) => void;
   onCancel?: () => void;
   className?: string;
+  /** Ref al elemento <form>. El caller puede disparar submit con `formRef.current?.requestSubmit()` */
+  formRef?: React.Ref<HTMLFormElement>;
+  /** Si es true, el form no renderiza sus propios botones (los pone el caller en el footer del dialog) */
+  hideActions?: boolean;
+  /** Notifica al caller cuando cambia el estado de guardado (para deshabilitar el botón externo) */
+  onSavingChange?: (saving: boolean) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -20,6 +20,10 @@ export interface SectionDef {
 export interface ActionDef<T = unknown> {
   label: string;
   onClick: (item: T) => void;
+  /** Nombre de ícono Lucide para mostrar antes del label */
+  icon?: string;
+  /** Variante visual del botón. Default: 'default' (acento brand) */
+  variant?: 'default' | 'outline' | 'destructive' | 'ghost' | 'secondary' | 'brand';
 }
 
 export interface ColumnDef<T = unknown> {

--- a/src/views/consultation-detail/index.tsx
+++ b/src/views/consultation-detail/index.tsx
@@ -19,6 +19,8 @@ export function ConsultationDetailView(props: { consultationId?: string }) {
 
   const [showEditModal, setShowEditModal] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const { softDelete } = useConsultationMutations();
 
   const handleBack = useCallback(() => {
@@ -34,15 +36,21 @@ export function ConsultationDetailView(props: { consultationId?: string }) {
     setRefreshKey((k: number) => k + 1);
   }, []);
 
-  const handleDelete = useCallback(
-    (c: Consultation) => {
-      if (!confirm('¿Eliminar esta consulta? Se puede restaurar posteriormente.')) return;
-      void softDelete(c.id).then(() => {
-        views.open('consultations.list.open');
-      });
-    },
-    [softDelete, views]
-  );
+  const handleDelete = useCallback((_c: Consultation) => {
+    setConfirmDelete(true);
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!consultationId) return;
+    setDeleting(true);
+    try {
+      await softDelete(consultationId);
+      setConfirmDelete(false);
+      views.open('consultations.list.open');
+    } finally {
+      setDeleting(false);
+    }
+  }, [consultationId, softDelete, views]);
 
   if (!consultationId) {
     return React.createElement(UI.EmptyState, {
@@ -66,20 +74,36 @@ export function ConsultationDetailView(props: { consultationId?: string }) {
       })
     ),
 
-    // Modal de edicion
+    // Modal de edición con footer sticky
     showEditModal &&
-      React.createElement(UI.FormDialog, {
+      React.createElement(UI.FormDialogSubmit, {
         open: showEditModal,
         onOpenChange: (open: boolean) => {
           if (!open) setShowEditModal(false);
         },
         title: 'Editar consulta',
         size: 'lg',
-        children: React.createElement(ConsultationForm, {
-          consultationId,
-          onSuccess: handleEditSuccess,
-          onCancel: () => setShowEditModal(false),
-        }),
-      })
+        submitLabel: 'Guardar cambios',
+        onCancel: () => setShowEditModal(false),
+        children: ({ formRef }: { formRef: React.RefObject<HTMLFormElement> }) =>
+          React.createElement(ConsultationForm, {
+            consultationId,
+            onSuccess: handleEditSuccess,
+            formRef,
+            hideActions: true,
+          }),
+      }),
+
+    // Confirmar eliminación
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    React.createElement((UI as any).ConfirmDialog, {
+      open: confirmDelete,
+      onOpenChange: setConfirmDelete,
+      title: 'Eliminar consulta',
+      description: '¿Eliminar esta consulta?',
+      confirmLabel: 'Eliminar',
+      loading: deleting,
+      onConfirm: () => void handleConfirmDelete(),
+    })
   );
 }

--- a/src/views/detail-override/index.tsx
+++ b/src/views/detail-override/index.tsx
@@ -2,7 +2,7 @@
 // Reemplaza: patients.detail.open (del plugin: patients)
 // Importa PetDetail de @coongro/patients y agrega extraSections/extraActions de consultas.
 
-import { PetDetail, PetForm } from '@coongro/patients';
+import { PetDetail, PetForm, usePetMutations } from '@coongro/patients';
 import type { Pet } from '@coongro/patients';
 import { getHostReact, getHostUI, usePlugin, actions } from '@coongro/plugin-sdk';
 
@@ -23,6 +23,8 @@ export function DetailOverrideView(props: { petId?: string }) {
   const [showEditModal, setShowEditModal] = useState(false);
   const [showConsultationModal, setShowConsultationModal] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [confirmDelete, setConfirmDelete] = useState<Pet | null>(null);
+  const { softDelete, deleting } = usePetMutations();
 
   // Fetch de totales de servicios para pasar al timeline
   const { settings: consultSettings } = useConsultationsSettings();
@@ -75,12 +77,18 @@ export function DetailOverrideView(props: { petId?: string }) {
     [views]
   );
 
-  const handleDelete = useCallback(
-    (pet: Pet) => {
-      toast.warning('Confirmar', `¿Eliminar a ${pet.name}?`);
-    },
-    [toast]
-  );
+  const handleDelete = useCallback((pet: Pet) => {
+    setConfirmDelete(pet);
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!confirmDelete) return;
+    const ok = await softDelete(confirmDelete.id);
+    if (ok) {
+      setConfirmDelete(null);
+      views.open('patients.list.open');
+    }
+  }, [confirmDelete, softDelete, views]);
 
   const handleNavigate = useCallback(
     (viewId: string, params?: Record<string, unknown>) => {
@@ -117,6 +125,7 @@ export function DetailOverrideView(props: { petId?: string }) {
   const extraActions = [
     {
       label: 'Nueva Consulta',
+      icon: 'Plus',
       onClick: () => setShowConsultationModal(true),
     },
   ];
@@ -139,20 +148,24 @@ export function DetailOverrideView(props: { petId?: string }) {
       })
     ),
 
-    // Modal de edicion de paciente
+    // Modal de edición de paciente con footer sticky
     showEditModal &&
-      React.createElement(UI.FormDialog, {
+      React.createElement(UI.FormDialogSubmit, {
         open: showEditModal,
         onOpenChange: (open: boolean) => {
           if (!open) setShowEditModal(false);
         },
         title: 'Editar paciente',
         size: 'lg',
-        children: React.createElement(PetForm, {
-          petId,
-          onSuccess: handleEditSuccess,
-          onCancel: () => setShowEditModal(false),
-        }),
+        submitLabel: 'Guardar cambios',
+        onCancel: () => setShowEditModal(false),
+        children: ({ formRef }: { formRef: React.RefObject<HTMLFormElement> }) =>
+          React.createElement(PetForm, {
+            petId,
+            onSuccess: handleEditSuccess,
+            formRef,
+            hideActions: true,
+          }),
       }),
 
     React.createElement(CreateConsultationButton, {
@@ -160,6 +173,28 @@ export function DetailOverrideView(props: { petId?: string }) {
       open: showConsultationModal,
       onOpenChange: setShowConsultationModal,
       onSuccess: handleConsultationSuccess,
+    }),
+
+    // Confirmar eliminación
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    React.createElement((UI as any).ConfirmDialog, {
+      open: !!confirmDelete,
+      onOpenChange: (open: boolean) => {
+        if (!open) setConfirmDelete(null);
+      },
+      title: 'Eliminar paciente',
+      description: confirmDelete
+        ? React.createElement(
+            React.Fragment,
+            null,
+            '¿Eliminar a ',
+            React.createElement('strong', null, confirmDelete.name),
+            '?'
+          )
+        : '',
+      confirmLabel: 'Eliminar',
+      loading: deleting,
+      onConfirm: () => void handleConfirmDelete(),
     })
   );
 }


### PR DESCRIPTION
## Resumen

Adopta los nuevos componentes de \`@coongro/ui-components\` 0.28.0 para unificar el patrón de formularios del kit veterinario (COONG-112):

- **\`ConsultationForm\`** ahora usa \`UI.FormSection\` en sus 7 secciones SOAP (antes: \`UI.Card\` + helper local \`SectionHeader\` copy-pasted).
- **\`CreateConsultationButton\`** ahora usa \`UI.FormDialogSubmit\` (footer sticky con botones Cancelar/Registrar consulta siempre visibles, sin importar el scroll del form).
- **\`ConsultationFormProps\`** se extiende con \`formRef\`, \`hideActions\`, \`onSavingChange\` para que el caller pueda montar un footer sticky fuera del form. Compatible hacia atrás (todas opcionales).

## Test plan

- [x] \`npm run quality\` pasa (typecheck + lint + format)
- [x] \`npm run build\` OK
- [x] Verificación visual end-to-end en tenant de dev: dialog "Nueva consulta" abre, las 7 secciones renderan en cards, footer sticky con Cancelar/Registrar consulta, botón disabled mientras no hay paciente, "Guardando..." mientras submitea
- [ ] CI verde

## Dependencia

Requiere \`@coongro/ui-components\` >= 0.28.0 (ya publicado en Verdaccio staging).