### PR TITLE
fix: usar logger.info en seed de servicios veterinarios (COONG-158)

### DIFF
--- a/.changeset/fix-logger-info-seed.md
+++ b/.changeset/fix-logger-info-seed.md
@@ -1,0 +1,11 @@
+---
+'@coongro/consultations': patch
+---
+
+fix: usar logger.info y eliminar tipo ActivationAPI local desincronizado (COONG-158)
+
+El plugin declaraba una interfaz `ActivationAPI` local en `src/entry.ts` cuya forma del logger (`log/warn/error/debug`) no matcheaba la implementación real de `@coongro/core-logging` (`debug/info/warn/error/fatal`). En runtime `logger.log(...)` tiraba `TypeError` y el auto-seed de servicios veterinarios crasheaba en la primera línea, dejando la UI de Servicios vacía sin error visible.
+
+- Eliminada la interfaz local; ahora se importan `ModuleActivationContext` y `ModuleDatabaseAPI` desde `@coongro/plugin-sdk` (el `Logger` se deriva de `ModuleActivationContext['api']['logger']` porque el SDK aún no lo re-exporta directo).
+- `logger.log(...)` → `logger.info(...)` en las dos llamadas del seed.
+- Check explícito por `api.database` (opcional en `ModuleAPI`).

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -4,22 +4,13 @@
  * Auto-seed: crea categorías y servicios veterinarios por defecto
  * en @coongro/products la primera vez que se activa el plugin.
  */
-import type { ModuleDatabaseAPI } from '@coongro/plugin-sdk';
+import type { ModuleActivationContext, ModuleDatabaseAPI } from '@coongro/plugin-sdk';
 import { categoryTable, productTable } from '@coongro/products/server';
 import { eq } from 'drizzle-orm';
 
 import { ROOT_SERVICE_CATEGORY_SLUG as ROOT_CATEGORY_SLUG } from './constants/services.js';
 
-interface ActivationAPI {
-  logger: {
-    log: (...args: unknown[]) => void;
-    warn: (...args: unknown[]) => void;
-    error: (...args: unknown[]) => void;
-    debug: (...args: unknown[]) => void;
-  };
-  registerCommand: (id: string, handler: (...args: unknown[]) => unknown) => void;
-  database: ModuleDatabaseAPI;
-}
+type Logger = ModuleActivationContext['api']['logger'];
 
 // -----------------------------------------------------------------------
 // Datos de seed
@@ -97,7 +88,7 @@ const SERVICE_CATEGORIES: CategorySeed[] = [
 // Seed
 // -----------------------------------------------------------------------
 
-async function seedServices(db: ModuleDatabaseAPI, logger: ActivationAPI['logger']): Promise<void> {
+async function seedServices(db: ModuleDatabaseAPI, logger: Logger): Promise<void> {
   // Verificar si ya existe la categoría raíz (idempotencia por slug)
   const existing = await db.ormQuery((tx) =>
     tx
@@ -112,7 +103,7 @@ async function seedServices(db: ModuleDatabaseAPI, logger: ActivationAPI['logger
     return;
   }
 
-  logger.log('Seeding default veterinary service categories and services...');
+  logger.info('Seeding default veterinary service categories and services...');
 
   // Crear categoría raíz
   // Los type assertions son necesarios porque los genéricos de Drizzle
@@ -159,7 +150,7 @@ async function seedServices(db: ModuleDatabaseAPI, logger: ActivationAPI['logger
   }
   /* eslint-enable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any */
 
-  logger.log(
+  logger.info(
     `Seeded ${SERVICE_CATEGORIES.length} categories with ${SERVICE_CATEGORIES.reduce((acc, c) => acc + c.services.length, 0)} services`
   );
 }
@@ -168,8 +159,13 @@ async function seedServices(db: ModuleDatabaseAPI, logger: ActivationAPI['logger
 // Activate
 // -----------------------------------------------------------------------
 
-export async function activate(context: { api: ActivationAPI }): Promise<void> {
+export async function activate(context: ModuleActivationContext): Promise<void> {
   const { api } = context;
+
+  if (!api.database) {
+    api.logger.error('Cannot seed veterinary services: database API not available');
+    return;
+  }
 
   try {
     await seedServices(api.database, api.logger);


### PR DESCRIPTION
## Summary

- Elimina la interfaz `ActivationAPI` local de `src/entry.ts` cuya forma del logger no matcheaba la implementación real de `@coongro/core-logging` (causaba `TypeError: logger.log is not a function` en runtime y crasheaba el auto-seed).
- Usa `ModuleActivationContext` y `ModuleDatabaseAPI` del SDK + deriva `Logger` desde `ModuleActivationContext['api']['logger']`.
- Reemplaza `logger.log(...)` por `logger.info(...)` en las dos llamadas del seed; agrega guard explícito para `api.database` (opcional en `ModuleAPI`).

Plane: [COONG-158](https://app.plane.so) · Detectado en tenant Observability (`b4ffb480...`) al reinstalar kit-veterinary y ver que los servicios no se sembraban.

## Test plan

- [ ] Quality + build verdes en CI.
- [ ] Tras mergear y publicar a Verdaccio, reactivar `@coongro/consultations` en `/dev/panel` de un tenant con kit-veterinary instalado.
- [ ] Verificar en DB del tenant que `module_products_categories` contiene `_vet-services-root` y que `module_products_products` tiene ~30 filas con `metadata->>'type' = 'service'`.
- [ ] Verificar en kit-observability el log `'Seeded N categories with M services'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)