### PR TITLE
Integración de cobros: las consultas registran sus servicios en billing

### DIFF
--- a/.changeset/cobros-consulta-integration.md
+++ b/.changeset/cobros-consulta-integration.md
@@ -1,0 +1,5 @@
+---
+"@coongro/consultations": minor
+---
+
+Las consultas ahora registran sus servicios como cobros en el módulo de cuentas (@coongro/billing). Al guardar o editar una consulta, sus líneas de servicio se sincronizan con la cuenta de la visita; re-guardar reemplaza las líneas en vez de duplicarlas, y las vacunas aplicadas en la misma visita no se tocan. Es una dependencia blanda: si billing no está instalado, la consulta se guarda igual.

--- a/src/data/billing.ts
+++ b/src/data/billing.ts
@@ -1,0 +1,59 @@
+import { actions } from '@coongro/plugin-sdk';
+
+/** Línea de servicio mínima necesaria para generar el cobro. */
+export interface BillableServiceLine {
+  id: string;
+  product_id: string | null;
+  product_name: string;
+  quantity: string;
+  unit_price: string;
+  subtotal: string;
+}
+
+export interface SyncConsultationChargesParams {
+  consultationId: string;
+  /** Dueño de la mascota (contacto). Si no se resuelve, la cuenta queda sin cliente. */
+  contactId: string | null;
+  petId: string;
+  services: BillableServiceLine[];
+}
+
+/**
+ * Sincroniza las líneas de servicio de una consulta hacia su "cuenta de atención"
+ * (@coongro/billing): abre/reusa la cuenta de la visita (una por consulta) y reemplaza
+ * las líneas de tipo 'service' por el set actual. Idempotente y consistente en ediciones
+ * (re-guardar la consulta NO duplica el cobro) y no toca otras líneas de la cuenta —
+ * ej. vacunas aplicadas en la misma visita.
+ *
+ * Dependencia BLANDA: si billing no está instalado, la consulta igual quedó registrada;
+ * simplemente no se genera el cobro. No interrumpe el flujo clínico.
+ */
+export async function syncConsultationCharges({
+  consultationId,
+  contactId,
+  petId,
+  services,
+}: SyncConsultationChargesParams): Promise<void> {
+  if (!consultationId || !petId) return;
+  try {
+    const account = await actions.execute<{ id: string } | undefined>(
+      'billing.accounts.openForVisit',
+      { contactId: contactId ?? null, petId, consultationId }
+    );
+    if (!account?.id) return;
+    await actions.execute('billing.lines.syncSource', {
+      accountId: account.id,
+      sourceType: 'service',
+      lines: services.map((s) => ({
+        productId: s.product_id,
+        description: s.product_name,
+        quantity: s.quantity,
+        unitPrice: s.unit_price,
+        subtotal: s.subtotal,
+        sourceRef: s.id,
+      })),
+    });
+  } catch {
+    /* billing no disponible — la consulta igual quedó registrada */
+  }
+}

--- a/src/hooks/useConsultationMutations.ts
+++ b/src/hooks/useConsultationMutations.ts
@@ -5,6 +5,8 @@
 import { useTenantTimezone } from '@coongro/calendar';
 import { getHostReact, actions, usePlugin } from '@coongro/plugin-sdk';
 
+import { syncConsultationCharges } from '../data/billing.js';
+import type { BillableServiceLine } from '../data/billing.js';
 import type {
   Consultation,
   ConsultationCreateData,
@@ -21,6 +23,33 @@ async function resolvePetName(petId: string): Promise<string> {
     id: petId,
   });
   return pet?.name ?? 'Paciente';
+}
+
+async function resolvePetOwner(petId: string): Promise<string | null> {
+  try {
+    const pet = await actions.execute<{ owner_id: string | null } | undefined>(
+      'patients.pets.getById',
+      { id: petId }
+    );
+    return pet?.owner_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Empuja las líneas de servicio de la consulta hacia el módulo de cobros (@coongro/billing).
+ * Lee las líneas ya persistidas (autoritativas, con id), resuelve el dueño y sincroniza.
+ * Dependencia blanda: si billing falta, no rompe el guardado de la consulta.
+ */
+async function pushConsultationCharges(consultationId: string, petId: string): Promise<void> {
+  const services = await actions
+    .execute<BillableServiceLine[]>('consultations.services.listByConsultation', {
+      consultationId,
+    })
+    .catch((): BillableServiceLine[] => []);
+  const contactId = await resolvePetOwner(petId);
+  await syncConsultationCharges({ consultationId, contactId, petId, services });
 }
 
 export interface UseConsultationMutationsResult {
@@ -85,6 +114,12 @@ export function useConsultationMutations(): UseConsultationMutationsResult {
         }
 
         if (promises.length > 0) await Promise.all(promises);
+
+        // Empujar las líneas de servicio al módulo de cobros (solo si hay servicios,
+        // para no abrir cuentas vacías en consultas sin cargos).
+        if (services && services.length > 0) {
+          await pushConsultationCharges(consultation.id, consultation.pet_id);
+        }
 
         // Sincronizar evento de seguimiento en calendario
         if (consultation.follow_up_date) {
@@ -160,6 +195,10 @@ export function useConsultationMutations(): UseConsultationMutationsResult {
         // Sincronizar o eliminar evento de seguimiento
         const updated = result[0];
         if (updated) {
+          // Re-sincronizar cobros si se tocaron los servicios (reemplaza, no duplica).
+          if (services !== undefined) {
+            await pushConsultationCharges(id, updated.pet_id);
+          }
           if (updated.follow_up_date) {
             const petName = await resolvePetName(updated.pet_id);
             await syncFollowUpEvent(updated, petName, tz);


### PR DESCRIPTION
@
## Qué hace

Al guardar o editar una consulta, sus **líneas de servicio** se sincronizan con la **cuenta de la visita** en `@coongro/billing`:

- `billing.accounts.openForVisit` → una cuenta por consulta (reusa si ya existe).
- `billing.lines.syncSource` (nuevo en billing) → reemplaza las líneas de tipo `service` por el set actual. **Idempotente**: re-guardar la consulta no duplica los cobros, y las **vacunas** aplicadas en la misma visita no se tocan.

## Dependencia blanda

Si `@coongro/billing` no está instalado, la consulta se guarda igual y el flujo clínico no se interrumpe (todo en `try/catch`).

## Cómo se probó (tenant Veterinaria)

1. Consulta con servicio "Consulta general" → se creó una cuenta **Consulta** separada de la venta de mostrador de una vacuna del mismo paciente.
2. Se le puso precio al servicio ($8.000) y se re-guardó la consulta → la cuenta refleja **$8.000 con una sola línea** (sin duplicar) y la línea de la vacuna quedó intacta.

## Notas

- Requiere el método `billing.lines.syncSource` (plugin `@coongro/billing`, repo local — aún no publicado a GitHub).
- Tarea de Plane pendiente de crear (trabajo preparatorio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@