### PR TITLE
fix(cobros): la cuenta se fecha según la consulta, no el momento de guardado

### DIFF
--- a/.changeset/billing-account-date.md
+++ b/.changeset/billing-account-date.md
@@ -1,0 +1,5 @@
+---
+"@coongro/consultations": patch
+---
+
+La cuenta de cobro de una consulta ahora queda fechada según la fecha de la consulta (su fecha de negocio), no según el momento del guardado. Antes, al sincronizar con @coongro/billing, la cuenta usaba la fecha de creación; eso hacía que una consulta con fecha retroactiva apareciera en el día equivocado en los reportes de ingresos. Se pasa la fecha de la consulta a `billing.accounts.openForVisit`.

--- a/src/data/billing.ts
+++ b/src/data/billing.ts
@@ -16,6 +16,12 @@ export interface SyncConsultationChargesParams {
   contactId: string | null;
   petId: string;
   services: BillableServiceLine[];
+  /**
+   * Fecha de la consulta (UTCTimestamp ISO). Es la fecha de negocio del cobro: la cuenta
+   * debe quedar fechada según la consulta —no según el momento del guardado— para que los
+   * reportes de ingresos por período sean correctos incluso con consultas retroactivas.
+   */
+  consultationDate?: string | null;
 }
 
 /**
@@ -33,12 +39,13 @@ export async function syncConsultationCharges({
   contactId,
   petId,
   services,
+  consultationDate = null,
 }: SyncConsultationChargesParams): Promise<void> {
   if (!consultationId || !petId) return;
   try {
     const account = await actions.execute<{ id: string } | undefined>(
       'billing.accounts.openForVisit',
-      { contactId: contactId ?? null, petId, consultationId }
+      { contactId: contactId ?? null, petId, consultationId, openedAt: consultationDate }
     );
     if (!account?.id) return;
     await actions.execute('billing.lines.syncSource', {

--- a/src/hooks/useConsultationMutations.ts
+++ b/src/hooks/useConsultationMutations.ts
@@ -42,14 +42,18 @@ async function resolvePetOwner(petId: string): Promise<string | null> {
  * Lee las líneas ya persistidas (autoritativas, con id), resuelve el dueño y sincroniza.
  * Dependencia blanda: si billing falta, no rompe el guardado de la consulta.
  */
-async function pushConsultationCharges(consultationId: string, petId: string): Promise<void> {
+async function pushConsultationCharges(
+  consultationId: string,
+  petId: string,
+  consultationDate: string | null
+): Promise<void> {
   const services = await actions
     .execute<BillableServiceLine[]>('consultations.services.listByConsultation', {
       consultationId,
     })
     .catch((): BillableServiceLine[] => []);
   const contactId = await resolvePetOwner(petId);
-  await syncConsultationCharges({ consultationId, contactId, petId, services });
+  await syncConsultationCharges({ consultationId, contactId, petId, services, consultationDate });
 }
 
 export interface UseConsultationMutationsResult {
@@ -118,7 +122,7 @@ export function useConsultationMutations(): UseConsultationMutationsResult {
         // Empujar las líneas de servicio al módulo de cobros (solo si hay servicios,
         // para no abrir cuentas vacías en consultas sin cargos).
         if (services && services.length > 0) {
-          await pushConsultationCharges(consultation.id, consultation.pet_id);
+          await pushConsultationCharges(consultation.id, consultation.pet_id, consultation.date);
         }
 
         // Sincronizar evento de seguimiento en calendario
@@ -197,7 +201,7 @@ export function useConsultationMutations(): UseConsultationMutationsResult {
         if (updated) {
           // Re-sincronizar cobros si se tocaron los servicios (reemplaza, no duplica).
           if (services !== undefined) {
-            await pushConsultationCharges(id, updated.pet_id);
+            await pushConsultationCharges(id, updated.pet_id, updated.date);
           }
           if (updated.follow_up_date) {
             const petName = await resolvePetName(updated.pet_id);


### PR DESCRIPTION
@
## Qué arregla

Al sincronizar una consulta con `@coongro/billing`, la cuenta de cobro se fechaba con su timestamp de creación (`now()`). Una consulta con **fecha retroactiva** quedaba en el día equivocado en los reportes de ingresos del dashboard.

Ahora `syncConsultationCharges` pasa la **fecha de la consulta** a `billing.accounts.openForVisit` (`openedAt`), que es la fecha de negocio del cobro.

## Por qué importa (producción)

En una clínica real se cargan consultas con fecha pasada. Sin esto, esos ingresos se imputan al día de carga en vez del día real de atención.

## Depende de

`billing.accounts.openForVisit` con parámetro `openedAt` (ya en el repo local de billing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@