### PR TITLE
feat(consultations): Plan de tratamiento unificado + toggle de precios (COONG-214)

### DIFF
--- a/.changeset/plan-tratamiento-unificado.md
+++ b/.changeset/plan-tratamiento-unificado.md
@@ -1,0 +1,5 @@
+---
+"@coongro/consultations": minor
+---
+
+Plan de tratamiento unificado en el formulario de consulta (P de SOAP): medicamentos, servicios y seguimiento bajo una sola sección "P — Plan de tratamiento", con un toggle de precios visible/oculto. Reusa los editores existentes (MedicationFormList, ServiceLineForm) y el mecanismo de view-contributions (la sección de medicación/vacunas contribuida sigue funcionando), sin cambios en la lógica de guardado. El interleave pixel-exacto de la lista única y el precio por medicamento quedan diferidos (requieren schema).

--- a/src/components/ConsultationForm.tsx
+++ b/src/components/ConsultationForm.tsx
@@ -6,8 +6,8 @@
  *   3. S — Motivo + Anamnesis
  *   4. O — Examen físico por sistemas
  *   5. A — Diagnóstico
- *   6. P — Tratamiento + Medicamentos + Seguimiento
- *   7. Servicios prestados (facturación)
+ *   6. P — Plan de tratamiento: indicaciones + medicamentos + servicios/vacunas + seguimiento
+ *      (unificado en una sola sección con toggle de precios, ver PlanTratamiento)
  */
 import { DatePicker, DateTimePicker, TimePicker, useTenantTimezone } from '@coongro/calendar';
 import { localToUTC, parseDateKey, toDateKey, utcToLocal } from '@coongro/datetime';
@@ -40,7 +40,7 @@ import {
 
 import { ExamSystemList } from './ExamSystemRow.js';
 import { MedicationFormList } from './MedicationFormList.js';
-import { ServiceLineForm } from './ServiceLineForm.js';
+import { PlanTratamiento } from './PlanTratamiento.js';
 
 const React = getHostReact();
 const UI = getHostUI();
@@ -672,22 +672,28 @@ export function ConsultationForm(props: ConsultationFormProps) {
           placeholder: 'Ej: Dieta blanda, reposo, collar isabelino...',
         })
       ),
-      React.createElement(UI.Label, null, 'Medicación'),
-      ...(contributedSections.length > 0
-        ? contributedSections.map((s, i) =>
-            React.createElement(
-              React.Fragment,
-              { key: `contrib-${String(i)}` },
-              s.render() as React.ReactNode
-            )
-          )
-        : [
-            React.createElement(MedicationFormList, {
-              key: 'native-meds',
-              medications,
-              onChange: setMedications,
-            }),
-          ]),
+      React.createElement(PlanTratamiento, {
+        medicationsNode:
+          contributedSections.length > 0
+            ? contributedSections.map((s, i) =>
+                React.createElement(
+                  React.Fragment,
+                  { key: `contrib-${String(i)}` },
+                  s.render() as React.ReactNode
+                )
+              )
+            : React.createElement(MedicationFormList, {
+                medications,
+                onChange: setMedications,
+              }),
+        services: serviceLines,
+        onServicesChange: setServiceLines,
+        catalog: serviceCatalog,
+        categories: serviceSubcategories,
+        catalogLoading,
+        onProductCreated: handleProductCreated,
+        defaultShowPrices: consultSettings.showPrices,
+      }),
       React.createElement(UI.Separator, { className: 'my-1' }),
       React.createElement(SectionHeader, { icon: 'CalendarCheck', title: 'Seguimiento' }),
       React.createElement(
@@ -743,21 +749,6 @@ export function ConsultationForm(props: ConsultationFormProps) {
           })
         )
       )
-    ),
-
-    // ── Sección 7: Servicios prestados ──
-    React.createElement(
-      UI.FormSection,
-      { icon: 'Receipt', title: 'Servicios prestados' },
-      React.createElement(ServiceLineForm, {
-        services: serviceLines,
-        onChange: setServiceLines,
-        catalog: serviceCatalog,
-        categories: serviceSubcategories,
-        catalogLoading,
-        onProductCreated: handleProductCreated,
-        showPrices: consultSettings.showPrices,
-      })
     ),
 
     // ── Botones (solo si el caller no los pone en el footer del dialog) ──

--- a/src/components/PlanTratamiento.tsx
+++ b/src/components/PlanTratamiento.tsx
@@ -1,0 +1,123 @@
+/**
+ * Plan de tratamiento (P de SOAP) — sección unificada de la consulta.
+ *
+ * Diseño aprobado (A:/Coongro2/Plan Tratamiento): "lo que le indicás, recetás y
+ * aplicás al paciente" en UN solo lugar. Acá se consolidan medicamentos +
+ * servicios bajo una sola tarjeta, con un toggle de precios visible/oculto.
+ *
+ * Reusa los editores probados (MedicationFormList / ServiceLineForm) en vez de
+ * reescribirlos: la lógica de guardado del form (medications[] + services[]) NO
+ * cambia, así que el wiring a consultations.medications / consultations.services
+ * queda intacto.
+ *
+ * Diferido vs diseño exacto (necesita schema / cross-plugin, ver memoria
+ * plan_tratamiento_spec_coong214): lista única interleaved por tipo, ítem de tipo
+ * "vacuna" con registro en el carnet (plugin vaccination), y precio por
+ * medicamento (el modelo MedicationInput no tiene precio).
+ */
+import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+import type { Product, Category } from '@coongro/products';
+
+import type { ServiceLineInput } from '../types/consultation.js';
+
+import { ServiceLineForm } from './ServiceLineForm.js';
+
+const React = getHostReact();
+const UI = getHostUI();
+const { useState } = React;
+
+export interface PlanTratamientoProps {
+  /**
+   * Nodo de medicación ya resuelto por el form (sección contribuida por un
+   * plugin, o la MedicationFormList nativa). Se recibe armado para no romper el
+   * mecanismo de view-contributions de consultations.form.open.
+   */
+  medicationsNode: React.ReactNode;
+  services: ServiceLineInput[];
+  onServicesChange: (services: ServiceLineInput[]) => void;
+  catalog: Product[];
+  categories: Category[];
+  catalogLoading?: boolean;
+  onProductCreated?: (product: Product) => void;
+  /** Default de visibilidad de precios (setting consultations.showPrices). */
+  defaultShowPrices?: boolean;
+}
+
+function BlockLabel({ icon, title, note }: { icon: string; title: string; note?: string }) {
+  return React.createElement(
+    'div',
+    { className: 'flex items-center gap-2 text-xs font-semibold text-cg-text-muted' },
+    React.createElement(UI.DynamicIcon, { icon, size: 13 }),
+    title,
+    note && React.createElement('span', { className: 'font-normal text-cg-text-muted/70' }, note)
+  );
+}
+
+export function PlanTratamiento({
+  medicationsNode,
+  services,
+  onServicesChange,
+  catalog,
+  categories,
+  catalogLoading = false,
+  onProductCreated,
+  defaultShowPrices = true,
+}: PlanTratamientoProps) {
+  // El toggle de precios es local a la sección (el setting define el default).
+  const [pricesVisible, setPricesVisible] = useState(defaultShowPrices !== false);
+
+  return React.createElement(
+    'div',
+    { className: 'flex flex-col gap-4' },
+
+    // Toggle de precios (eye / eye-off), alineado a la derecha.
+    React.createElement(
+      'div',
+      { className: 'flex justify-end' },
+      React.createElement(
+        UI.Button,
+        {
+          type: 'button',
+          variant: 'ghost',
+          size: 'xs',
+          onClick: () => setPricesVisible((v: boolean) => !v),
+          title: 'Mostrar u ocultar los precios de esta sección',
+        },
+        React.createElement(UI.DynamicIcon, { icon: pricesVisible ? 'Eye' : 'EyeOff', size: 14 }),
+        pricesVisible ? 'Precios visibles' : 'Precios ocultos'
+      )
+    ),
+
+    // Bloque medicamentos.
+    React.createElement(
+      'div',
+      { className: 'flex flex-col gap-2' },
+      React.createElement(BlockLabel, {
+        icon: 'Pill',
+        title: 'Medicamentos',
+        note: '— lo que recetás',
+      }),
+      medicationsNode
+    ),
+
+    // Bloque servicios y vacunas.
+    React.createElement(
+      'div',
+      { className: 'flex flex-col gap-2' },
+      React.createElement(BlockLabel, {
+        icon: 'Receipt',
+        title: 'Servicios',
+        note: '— lo que prestás',
+      }),
+      React.createElement(ServiceLineForm, {
+        services,
+        onChange: onServicesChange,
+        catalog,
+        categories,
+        catalogLoading,
+        onProductCreated,
+        showPrices: pricesVisible,
+      })
+    )
+  );
+}


### PR DESCRIPTION
Unifica medicamentos, servicios y seguimiento bajo una sola sección 'P — Plan de tratamiento' (diseño A:/Coongro2/Plan Tratamiento), con toggle de precios visible/oculto. Reusa los editores existentes (MedicationFormList/ServiceLineForm) + el mecanismo de view-contributions (la sección de medicación/vacunas contribuida —que registra vacunas en el carnet— sigue intacta), SIN cambios en la lógica de guardado → cero riesgo al wiring de consultations.medications/services.

**Verificado en dev** (tenant Veterinaria, sesión real): el form renderiza la sección P con Indicaciones generales + toggle 'Precios visibles' + bloque Medicamentos (con vacunas contribuidas) + bloque Servicios + Seguimiento, sin errores.

Diferido (requiere schema/cross-plugin, anclado en memoria plan_tratamiento_spec_coong214): lista única interleaved pixel-exacta y precio por medicamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)